### PR TITLE
Add server and dynamic file listing

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,16 +57,20 @@
       background: #0ff;
       color: #111;
     }
+    .dashboard ul {
+      list-style: none;
+      padding: 0;
+    }
+    .dashboard li {
+      margin: 0.5rem 0;
+    }
   </style>
 </head>
 <body>
   <canvas id="bg"></canvas>
   <div class="dashboard">
-    <h1>Fitness Tracker Demos</h1>
-    <a href="gemini.html">Android Training Protocol v5<br><small>gemini.html</small></a>
-    <a href="claude.html">CyberFit &ndash; Train Like an Android<br><small>claude.html</small></a>
-    <a href="deepseek.html">NeoGrid Fitness &ndash; Precision Training<br><small>deepseek.html</small></a>
-    <a href="gpt.html">Infinite 3D Terrain Demo<br><small>gpt.html</small></a>
+    <h1>KodeDok DEV</h1>
+    <ul id="file-list"></ul>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/three@0.153.0/build/three.min.js"></script>
@@ -111,6 +115,21 @@
       camera.updateProjectionMatrix();
       renderer.setSize(window.innerWidth, window.innerHeight);
     });
+  </script>
+  <script>
+    fetch('/files')
+      .then(r => r.json())
+      .then(files => {
+        const list = document.getElementById('file-list');
+        files.forEach(f => {
+          const li = document.createElement('li');
+          const a = document.createElement('a');
+          a.href = f;
+          a.textContent = f;
+          li.appendChild(a);
+          list.appendChild(li);
+        });
+      });
   </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "dev",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,44 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const dirPath = __dirname;
+
+function sendFile(res, filePath) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+    } else {
+      const ext = path.extname(filePath).toLowerCase();
+      const type = ext === '.html' || ext === '.htm' ? 'text/html' : 'text/plain';
+      res.writeHead(200, { 'Content-Type': type });
+      res.end(data);
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/files') {
+    fs.readdir(dirPath, (err, files) => {
+      if (err) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Unable to list files' }));
+        return;
+      }
+      const htmlFiles = files.filter(f => (f.endsWith('.html') || f.endsWith('.htm')) && f !== 'index.html');
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(htmlFiles));
+    });
+  } else if (req.url === '/' || req.url === '/index.html') {
+    sendFile(res, path.join(dirPath, 'index.html'));
+  } else {
+    const filePath = path.join(dirPath, req.url);
+    sendFile(res, filePath);
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- update heading to `KodeDok DEV`
- fetch file list from `/files` endpoint and populate the dashboard
- style the new file list
- add a small Node server that provides `/files` and serves static files

## Testing
- `npm test` *(fails: Error: no test specified)*
- `curl http://localhost:3000/files`

------
https://chatgpt.com/codex/tasks/task_e_6878e5d5dfa4832abe2ab1846b78ca9a