### PR TITLE
Fix JSON caching and query parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
     });
   </script>
   <script>
-    fetch('data/files.json')
+    fetch(`data/files.json?cache=${Date.now()}`)
       .then(r => r.json())
       .then(data => {
         const list = document.getElementById('file-list');

--- a/server.js
+++ b/server.js
@@ -19,7 +19,10 @@ function sendFile(res, filePath) {
 }
 
 const server = http.createServer((req, res) => {
-  if (req.url === '/files') {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const pathname = url.pathname;
+
+  if (pathname === '/files') {
     fs.readdir(dirPath, (err, files) => {
       if (err) {
         res.writeHead(500, { 'Content-Type': 'application/json' });
@@ -30,10 +33,10 @@ const server = http.createServer((req, res) => {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(htmlFiles));
     });
-  } else if (req.url === '/' || req.url === '/index.html') {
+  } else if (pathname === '/' || pathname === '/index.html') {
     sendFile(res, path.join(dirPath, 'index.html'));
   } else {
-    const filePath = path.join(dirPath, req.url);
+    const filePath = path.join(dirPath, pathname);
     sendFile(res, filePath);
   }
 });


### PR DESCRIPTION
## Summary
- bust browser cache for `data/files.json` by adding timestamp
- ensure server handles query parameters correctly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6878f8c246fc832a9f5fc5db79ae76fb