### PR TITLE
Add simple JSON-based CMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ This project includes a small Node.js server used to serve `index.html` and list
 ## Notes
 
 The `server.js` file scans the project directory for HTML files. When you add more `.html`/`.htm` files alongside `index.html`, they will automatically appear in the list on the dashboard page once you refresh the page.
+
+## JSON based content pages
+
+Content pages are now stored as JSON files inside `data/pages`. The list of pages is defined in `data/pages.json`. Each page JSON contains a `title` and `body` field. The `page.html` template reads these files and displays the content dynamically.
+
+To add a new page:
+
+1. Create a new JSON file in `data/pages` (e.g. `my-page.json`).
+2. Add an entry for it in `data/pages.json` with the desired slug and title.
+3. Navigate to `page.html?slug=my-page` to view it.

--- a/data/pages.json
+++ b/data/pages.json
@@ -1,0 +1,6 @@
+{
+  "pages": [
+    {"slug": "welcome", "title": "Welcome"},
+    {"slug": "about", "title": "About"}
+  ]
+}

--- a/data/pages/about.json
+++ b/data/pages/about.json
@@ -1,0 +1,4 @@
+{
+  "title": "About",
+  "body": "<p>This is an example about page loaded from a JSON file.</p>"
+}

--- a/data/pages/welcome.json
+++ b/data/pages/welcome.json
@@ -1,0 +1,4 @@
+{
+  "title": "Welcome",
+  "body": "<p>This is the welcome page of our simple JSON based CMS.</p><p>You can easily add more pages by editing JSON files.</p>"
+}

--- a/index.html
+++ b/index.html
@@ -70,6 +70,9 @@
   <canvas id="bg"></canvas>
   <div class="dashboard">
     <h1>KodeDok DEV</h1>
+    <h2>Pages</h2>
+    <ul id="page-list"></ul>
+    <h2>Demos</h2>
     <ul id="file-list"></ul>
   </div>
 
@@ -117,6 +120,20 @@
     });
   </script>
   <script>
+    fetch(`data/pages.json?cache=${Date.now()}`)
+      .then(r => r.json())
+      .then(data => {
+        const list = document.getElementById('page-list');
+        data.pages.forEach(p => {
+          const li = document.createElement('li');
+          const a = document.createElement('a');
+          a.href = `page.html?slug=${encodeURIComponent(p.slug)}`;
+          a.textContent = p.title;
+          li.appendChild(a);
+          list.appendChild(li);
+        });
+      });
+
     fetch(`data/files.json?cache=${Date.now()}`)
       .then(r => r.json())
       .then(data => {

--- a/page.html
+++ b/page.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Loading...</title>
+  <style>
+    body{font-family:Arial,Helvetica,sans-serif;margin:0;padding:20px;max-width:800px;margin:auto;background:#111;color:#0ff}
+    a{color:#0ff}
+  </style>
+</head>
+<body>
+  <h1 id="title">Loading...</h1>
+  <div id="content"></div>
+  <script>
+    const params=new URLSearchParams(location.search);
+    const slug=params.get('slug');
+    const titleEl=document.getElementById('title');
+    const contentEl=document.getElementById('content');
+    if(!slug){
+      titleEl.textContent='Error';
+      contentEl.textContent='No page specified.';
+    }else{
+      fetch(`data/pages/${slug}.json?cache=${Date.now()}`)
+        .then(r=>r.json())
+        .then(data=>{
+          titleEl.textContent=data.title||slug;
+          document.title=data.title||slug;
+          contentEl.innerHTML=data.body||'';
+        })
+        .catch(()=>{
+          titleEl.textContent='Not Found';
+          contentEl.textContent='Page not found.';
+        });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- list content pages and demos on the home page
- use `pages.json` to drive the page list
- add `page.html` that loads content from JSON files
- document how to add pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6879219aa74c832ab8498068fad84fcc