### PR TITLE
Improve TRON dashboard styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Fitness Tracker Dashboard</title>
+  <title>KodeDok DEV Dashboard</title>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600&display=swap" rel="stylesheet">
   <style>
     body {
@@ -13,9 +13,11 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background: #111;
-      color: #0ff;
+      background: #000;
+      color: #00ffff;
       font-family: 'Orbitron', sans-serif;
+      font-weight: 600;
+      text-shadow: 0 0 8px #00ffff, 0 0 2px #0088aa;
     }
     #bg {
       position: fixed;
@@ -29,24 +31,35 @@
       display: flex;
       flex-direction: column;
       gap: 1rem;
-      padding: 2rem 3rem;
+      padding: 2rem 1.5rem;
       border-radius: 8px;
       background: rgba(255,255,255,0.05);
-      box-shadow: 0 0 10px #0ff;
+      box-shadow: 0 0 10px #00ffff;
       text-align: center;
+      max-width: 480px;
+      width: 100%;
+      margin: auto;
     }
     .dashboard h1 {
       margin-top: 0;
-      margin-bottom: 1rem;
-      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+      font-size: 1.75rem;
+      text-transform: uppercase;
+      text-shadow: 0 0 8px #00ffff, 0 0 2px #0088aa;
+    }
+    .dashboard h2 {
+      margin: 1rem 0 0.5rem;
+      text-transform: uppercase;
+      text-shadow: 0 0 8px #00ffff;
     }
     .dashboard a {
-      color: #0ff;
+      color: #66ffff;
       text-decoration: none;
-      padding: 0.5rem 1rem;
-      border: 1px solid #0ff;
-      border-radius: 4px;
-      transition: background 0.3s, color 0.3s;
+      padding: 0.75rem 1.25rem;
+      border: 1px solid #00ffff;
+      border-radius: 6px;
+      transition: background 0.3s, color 0.3s, box-shadow 0.3s;
+      box-shadow: inset 0 0 6px #00ffff55;
     }
     .dashboard a small {
       display: block;
@@ -54,8 +67,9 @@
       margin-top: 0.25rem;
     }
     .dashboard a:hover {
-      background: #0ff;
-      color: #111;
+      background: #00ffaa;
+      color: #000;
+      text-shadow: 0 0 10px #00ffaa;
     }
     .dashboard ul {
       list-style: none;
@@ -63,6 +77,47 @@
     }
     .dashboard li {
       margin: 1rem 0; /* increased spacing between file entries */
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background:
+        repeating-linear-gradient(0deg, rgba(0,255,255,0.05) 0, rgba(0,255,255,0.05) 1px, transparent 1px, transparent 50px),
+        repeating-linear-gradient(90deg, rgba(0,255,255,0.05) 0, rgba(0,255,255,0.05) 1px, transparent 1px, transparent 50px);
+      animation: gridMove 30s linear infinite;
+      pointer-events: none;
+      z-index: -2;
+    }
+    @keyframes gridMove {
+      from {background-position:0 0,0 0;}
+      to {background-position:200px 200px,200px 200px;}
+    }
+
+    #tab-bar {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      display: flex;
+      justify-content: space-around;
+      background: #111111dd;
+      padding: 0.5rem 0;
+      font-size: 0.75rem;
+    }
+    #tab-bar a {
+      flex: 1;
+      color: #66ffff;
+      text-decoration: none;
+      text-align: center;
+    }
+    #tab-bar a.active {
+      color: #00ffff;
+      text-shadow: 0 0 8px #00ffff;
     }
   </style>
 </head>
@@ -75,6 +130,12 @@
     <h2>Demos</h2>
     <ul id="file-list"></ul>
   </div>
+  <nav id="tab-bar">
+    <a href="#" class="active">Begin</a>
+    <a href="#">Games</a>
+    <a href="#">Tabbladen</a>
+    <a href="#">Menu</a>
+  </nav>
 
   <script src="https://cdn.jsdelivr.net/npm/three@0.153.0/build/three.min.js"></script>
   <script>
@@ -106,6 +167,8 @@
       `
     });
     const torus = new THREE.Mesh(geometry, torusShader);
+    torus.material.transparent = true;
+    torus.material.opacity = 0.2;
     scene.add(torus);
 
     const pointLight = new THREE.PointLight(0xffffff, 1);


### PR DESCRIPTION
## Summary
- restyle dashboard to boost readability
- add neon glow text and animated grid background
- introduce bottom tab bar navigation
- fade background torus

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687925e8a654832a8ce089d35460dadd