### PR TITLE
Remove KodeDok from headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# KodeDok DEV
+# DEV
 
 This project includes a small Node.js server used to serve `index.html` and list any additional `.html` or `.htm` files in the project directory.
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>KodeDok DEV Dashboard</title>
+  <title>DEV Dashboard</title>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600&display=swap" rel="stylesheet">
   <style>
     body {
@@ -124,7 +124,7 @@
 <body>
   <canvas id="bg"></canvas>
   <div class="dashboard">
-    <h1>KodeDok DEV</h1>
+    <h1>DEV</h1>
     <h2>Pages</h2>
     <ul id="page-list"></ul>
     <h2>Demos</h2>


### PR DESCRIPTION
## Summary
- update README heading to `DEV`
- strip `KodeDok` from page title and main header

## Testing
- `grep -n "<title>" -n index.html`


------
https://chatgpt.com/codex/tasks/task_e_687929dc0d80832a98158b0a1e8cc635