### PR TITLE
Improve fallback handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,9 +201,19 @@
     });
   </script>
   <script>
-    fetch(`data/pages.json?cache=${Date.now()}`)
-      .then(r => r.json())
-      .then(data => {
+    function loadJson(url, fallback, callback) {
+      fetch(url)
+        .then(r => r.json())
+        .then(callback)
+        .catch(err => {
+          console.error('Failed to load', url, err);
+          callback(fallback);
+        });
+    }
+
+    loadJson(`data/pages.json?cache=${Date.now()}`,
+      { pages: [] },
+      data => {
         const list = document.getElementById('page-list');
         data.pages.forEach(p => {
           const li = document.createElement('li');
@@ -215,9 +225,9 @@
         });
       });
 
-    fetch(`data/files.json?cache=${Date.now()}`)
-      .then(r => r.json())
-      .then(data => {
+    loadJson(`data/files.json?cache=${Date.now()}`,
+      { demoFiles: [] },
+      data => {
         const list = document.getElementById('file-list');
         data.demoFiles.forEach(f => {
           const li = document.createElement('li');
@@ -230,9 +240,9 @@
       });
 
     // load site title
-    fetch(`data/site.json?cache=${Date.now()}`)
-      .then(r => r.json())
-      .then(data => {
+    loadJson(`data/site.json?cache=${Date.now()}`,
+      { title: 'DEV' },
+      data => {
         const titleEl = document.getElementById('site-title');
         if (data.title) {
           titleEl.textContent = data.title;


### PR DESCRIPTION
## Summary
- add `loadJson` helper in `index.html` for fetch fallbacks

## Testing
- `npm test` (fails due to no tests)

------
https://chatgpt.com/codex/tasks/task_e_68794859a97c832a93f469c8575b5f2d