### PR TITLE
Add debug console overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ To add a new page:
 1. Create a new JSON file in `data/pages` (e.g. `my-page.json`).
 2. Add an entry for it in `data/pages.json` with the desired slug and title.
 3. Navigate to `page.html?slug=my-page` to view it.
+
+## Debug Console
+
+All pages now include a simple JavaScript console overlay. Click the **Console** button in the bottom-right corner to open it and view log output or run code snippets.

--- a/debug-console.js
+++ b/debug-console.js
@@ -1,0 +1,43 @@
+(function(){
+  const overlay=document.createElement('div');
+  overlay.id='debug-console-overlay';
+  overlay.style.cssText=
+    'position:fixed;top:0;left:0;right:0;bottom:0;display:none;background:rgba(0,0,0,0.85);color:#0f0;font-family:monospace;font-size:12px;z-index:9999;padding:8px;box-sizing:border-box;flex-direction:column;';
+  const logEl=document.createElement('div');
+  logEl.style.cssText='flex:1;overflow-y:auto;white-space:pre-wrap;margin-bottom:4px;';
+  const input=document.createElement('input');
+  input.type='text';
+  input.style.cssText='width:100%;background:#000;color:#0f0;border:1px solid #0f0;box-sizing:border-box;padding:4px;';
+  overlay.appendChild(logEl);
+  overlay.appendChild(input);
+  document.addEventListener('DOMContentLoaded',()=>{
+    document.body.appendChild(overlay);
+    document.body.appendChild(btn);
+  });
+  let visible=false;
+  function toggle(){
+    visible=!visible;
+    overlay.style.display=visible?'flex':'none';
+    if(visible) input.focus();
+  }
+  const btn=document.createElement('button');
+  btn.textContent='Console';
+  btn.style.cssText='position:fixed;bottom:10px;right:10px;z-index:9999;background:#222;color:#0f0;border:1px solid #0f0;padding:4px;font-family:monospace;';
+  btn.addEventListener('click',toggle);
+  function log(...args){
+    logEl.textContent+=args.join(' ')+"\n";
+    logEl.scrollTop=logEl.scrollHeight;
+  }
+  const origLog=console.log;
+  const origErr=console.error;
+  console.log=function(...args){origLog.apply(console,args);log(...args);};
+  console.error=function(...args){origErr.apply(console,args);log('ERROR:',...args);};
+  input.addEventListener('keydown',e=>{
+    if(e.key==='Enter'){
+      const code=input.value;input.value='';
+      log('> '+code);
+      try{const res=eval(code);if(res!==undefined)log(res);}catch(err){log('ERROR:',err);}
+    }else if(e.key==='Escape'){toggle();}
+  });
+  window.debugConsoleToggle=toggle;
+})();

--- a/dev-new.html
+++ b/dev-new.html
@@ -159,5 +159,6 @@
       }
     });
   </script>
+  <script src="debug-console.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -250,5 +250,6 @@
         }
       });
   </script>
+  <script src="debug-console.js"></script>
 </body>
 </html>

--- a/kimi-tron-001.html
+++ b/kimi-tron-001.html
@@ -170,5 +170,6 @@
     startBtn.onclick= start;
     stopBtn.onclick = stop;
   </script>
+  <script src="debug-console.js"></script>
 </body>
 </html>

--- a/page.html
+++ b/page.html
@@ -34,5 +34,6 @@
         });
     }
   </script>
+  <script src="debug-console.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show a small "Console" button on all HTML pages
- open an overlayed JavaScript console to log output and run code
- document new feature in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68794acbc670832a9ea272f73d151ea6