### PR TITLE
Fix OSM load failure with local fallback

### DIFF
--- a/data/osm-sample.json
+++ b/data/osm-sample.json
@@ -1,0 +1,31 @@
+{
+  "elements": [
+    {
+      "type": "way",
+      "tags": {"highway": "residential"},
+      "geometry": [
+        {"lat": 52.3676, "lon": 4.9041},
+        {"lat": 52.3676, "lon": 4.9050}
+      ]
+    },
+    {
+      "type": "way",
+      "tags": {"highway": "residential"},
+      "geometry": [
+        {"lat": 52.3677, "lon": 4.9041},
+        {"lat": 52.3677, "lon": 4.9050}
+      ]
+    },
+    {
+      "type": "way",
+      "tags": {"building": "yes"},
+      "geometry": [
+        {"lat": 52.3678, "lon": 4.9042},
+        {"lat": 52.3679, "lon": 4.9042},
+        {"lat": 52.3679, "lon": 4.9045},
+        {"lat": 52.3678, "lon": 4.9045},
+        {"lat": 52.3678, "lon": 4.9042}
+      ]
+    }
+  ]
+}

--- a/dev-new.html
+++ b/dev-new.html
@@ -76,9 +76,14 @@
       const query=`[out:json];(way["highway"](${bbox.join(',')});way["building"](${bbox.join(',')}));out geom;`;
       const url='https://overpass-api.de/api/interpreter?data='+encodeURIComponent(query);
       fetch(url)
-        .then(r=>r.json())
+        .then(r=>{if(!r.ok)throw new Error('Network error');return r.json();})
         .then(data=>drawOSM(data,center))
-        .catch(e=>console.error('OSM load',e));
+        .catch(e=>{
+          console.error('OSM load',e);
+          fetch('data/osm-sample.json')
+            .then(r=>r.json())
+            .then(d=>drawOSM(d,center));
+        });
     }
 
     function drawOSM(data,center){


### PR DESCRIPTION
## Summary
- provide a minimal OSM dataset in `data/osm-sample.json`
- update `dev-new.html` to load this dataset if the online request fails

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_687956c84ae4832aaa482609696e6551