### PR TITLE
Create reusable console overlay library

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,19 @@ To add a new page:
 
 ## Debug Console
 
-All pages now include a simple JavaScript console overlay. Click the **Console** button in the bottom-right corner to open it and view log output or run code snippets.
+All pages now include a simple JavaScript console overlay. A reusable library is
+available in `console-overlay.js`. Include the script and call
+`createDebugConsole()` to enable it:
+
+```html
+<script src="console-overlay.js"></script>
+<script>createDebugConsole();</script>
+```
+
+You can pass options to customise the appearance, for example:
+
+```javascript
+createDebugConsole({ buttonLabel: 'Debug', color: '#0ff' });
+```
+
+Click the **Console** button in the bottom-right corner to toggle the overlay.

--- a/console-overlay.js
+++ b/console-overlay.js
@@ -1,0 +1,72 @@
+(function(global){
+  function createDebugConsole(options={}){
+    const {
+      buttonLabel='Console',
+      height='40vh',
+      background='rgba(0,0,0,0.8)',
+      color='#0f0',
+      fontFamily='monospace',
+      fontSize='12px',
+      zIndex=9999,
+      id='debug-console-overlay'
+    } = options;
+
+    const overlay=document.createElement('div');
+    overlay.id=id;
+    overlay.style.cssText=
+      `position:fixed;left:0;right:0;bottom:0;height:${height};display:none;`+
+      `background:${background};color:${color};font-family:${fontFamily};font-size:${fontSize};`+
+      `z-index:${zIndex};padding:8px;box-sizing:border-box;flex-direction:column;`;
+
+    const logEl=document.createElement('div');
+    logEl.style.cssText='flex:1;overflow-y:auto;white-space:pre-wrap;margin-bottom:4px;';
+
+    const input=document.createElement('input');
+    input.type='text';
+    input.style.cssText=`width:100%;background:#000;color:${color};border:1px solid ${color};box-sizing:border-box;padding:4px;`;
+
+    overlay.appendChild(logEl);
+    overlay.appendChild(input);
+
+    const btn=document.createElement('button');
+    btn.textContent=buttonLabel;
+    btn.style.cssText=`position:fixed;bottom:10px;right:10px;z-index:${zIndex};background:#222;color:${color};border:1px solid ${color};padding:4px;font-family:${fontFamily};`;
+
+    let visible=false;
+    function toggle(){
+      visible=!visible;
+      overlay.style.display=visible?'flex':'none';
+      if(visible) input.focus();
+    }
+    btn.addEventListener('click',toggle);
+
+    function log(...args){
+      logEl.textContent+=args.join(' ')+"\n";
+      logEl.scrollTop=logEl.scrollHeight;
+    }
+
+    const origLog=console.log;
+    const origErr=console.error;
+    console.log=function(...args){origLog.apply(console,args);log(...args);};
+    console.error=function(...args){origErr.apply(console,args);log('ERROR:',...args);};
+
+    input.addEventListener('keydown',e=>{
+      if(e.key==='Enter'){
+        const code=input.value;input.value='';
+        log('> '+code);
+        try{const res=eval(code);if(res!==undefined)log(res);}catch(err){log('ERROR:',err);}
+      }else if(e.key==='Escape'){
+        toggle();
+      }
+    });
+
+    document.addEventListener('DOMContentLoaded',()=>{
+      document.body.appendChild(overlay);
+      document.body.appendChild(btn);
+    });
+
+    return {toggle,log,button:btn,overlay};
+  }
+
+  global.createDebugConsole=createDebugConsole;
+})(typeof window!=='undefined'?window:this);

--- a/dev-new.html
+++ b/dev-new.html
@@ -164,6 +164,7 @@
       }
     });
   </script>
-  <script src="debug-console.js"></script>
+  <script src="console-overlay.js"></script>
+  <script>createDebugConsole();</script>
 </body>
 </html>

--- a/gemini-js-001.html
+++ b/gemini-js-001.html
@@ -151,6 +151,7 @@ document.addEventListener('DOMContentLoaded',()=>{
     });
 });
     </script>
-    <script src="debug-console.js"></script>
+    <script src="console-overlay.js"></script>
+    <script>createDebugConsole();</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -250,6 +250,7 @@
         }
       });
   </script>
-  <script src="debug-console.js"></script>
+  <script src="console-overlay.js"></script>
+  <script>createDebugConsole();</script>
 </body>
 </html>

--- a/kimi-tron-001.html
+++ b/kimi-tron-001.html
@@ -170,6 +170,7 @@
     startBtn.onclick= start;
     stopBtn.onclick = stop;
   </script>
-  <script src="debug-console.js"></script>
+  <script src="console-overlay.js"></script>
+  <script>createDebugConsole();</script>
 </body>
 </html>

--- a/page.html
+++ b/page.html
@@ -34,6 +34,7 @@
         });
     }
   </script>
-  <script src="debug-console.js"></script>
+  <script src="console-overlay.js"></script>
+  <script>createDebugConsole();</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `console-overlay.js` exposing `createDebugConsole`
- switch HTML pages to use the new library
- document usage and customization options in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a277d05d8832a951a7545ce60bd25