### PR TITLE
Add basic THREE.js demo

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -16,6 +16,11 @@ main {
   padding: 1rem;
 }
 
+#scene-container {
+  width: 100%;
+  height: 400px;
+}
+
 @media (min-width: 768px) {
   main {
     padding: 2rem;

--- a/index.html
+++ b/index.html
@@ -18,8 +18,9 @@ Change Log:
     <h1>Welcome</h1>
   </header>
   <main>
-    <p>Your content goes here.</p>
+    <div id="scene-container"></div>
   </main>
+  <script src="https://unpkg.com/three@0.159.0/build/three.min.js"></script>
   <script src="js/script.js"></script>
 </body>
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -1,2 +1,28 @@
-// Placeholder for site scripts
+// Basic THREE.js example with a spinning cube
 console.log('Responsive boilerplate loaded');
+
+// Ensure THREE is available
+if (typeof THREE !== 'undefined') {
+  const container = document.getElementById('scene-container');
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(75, container.clientWidth / container.clientHeight, 0.1, 1000);
+  const renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(container.clientWidth, container.clientHeight);
+  container.appendChild(renderer.domElement);
+
+  const geometry = new THREE.BoxGeometry();
+  const material = new THREE.MeshNormalMaterial();
+  const cube = new THREE.Mesh(geometry, material);
+  scene.add(cube);
+
+  camera.position.z = 3;
+
+  function animate() {
+    requestAnimationFrame(animate);
+    cube.rotation.x += 0.01;
+    cube.rotation.y += 0.01;
+    renderer.render(scene, camera);
+  }
+
+  animate();
+}


### PR DESCRIPTION
## Summary
- include a placeholder element to host a THREE.js scene
- load THREE.js from a CDN
- implement a simple spinning cube demo in `script.js`
- style the scene container

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b81c5dd0832a8f1fe6304fb5b0e1