### PR TITLE
Update styles for dark background and responsive canvas

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -9,16 +9,36 @@ body {
   font-family: Arial, sans-serif;
   line-height: 1.6;
   color: #333;
-  background: #fff;
+  background: #000;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 main {
   padding: 1rem;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #scene-container {
-  width: 100%;
-  height: 400px;
+  width: 848px;
+  height: 420px;
+  margin: 0 auto;
+}
+
+#scene-container canvas {
+  background: #000033;
+  display: block;
+}
+
+@media (max-width: 848px), (orientation: portrait) {
+  #scene-container {
+    width: 100%;
+    height: calc(100vw * 420 / 848);
+  }
 }
 
 @media (min-width: 768px) {

--- a/js/script.js
+++ b/js/script.js
@@ -8,6 +8,7 @@ if (typeof THREE !== 'undefined') {
   const camera = new THREE.PerspectiveCamera(75, container.clientWidth / container.clientHeight, 0.1, 1000);
   const renderer = new THREE.WebGLRenderer({ antialias: true });
   renderer.setSize(container.clientWidth, container.clientHeight);
+  renderer.setClearColor(0x000033);
   container.appendChild(renderer.domElement);
 
   const geometry = new THREE.BoxGeometry();
@@ -23,6 +24,17 @@ if (typeof THREE !== 'undefined') {
     cube.rotation.y += 0.01;
     renderer.render(scene, camera);
   }
+
+  function onWindowResize() {
+    const width = container.clientWidth;
+    const height = container.clientHeight;
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+    renderer.setSize(width, height);
+  }
+
+  window.addEventListener('resize', onWindowResize);
+  onWindowResize();
 
   animate();
 }


### PR DESCRIPTION
## Summary
- switch body background to black
- center and size scene canvas to 848x420
- use dark navy background for canvas
- update script to resize renderer on window changes

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6883bafee544832a942f72b9b171501c