### PR TITLE
Add cinematic heading and adjust camera

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -14,6 +14,7 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 main {
@@ -41,6 +42,30 @@ main {
   padding: 2px 4px;
   font-size: 0.8rem;
   pointer-events: none;
+}
+#cinematic-heading {
+  position: fixed;
+  top: 20px;
+  width: 100%;
+  text-align: center;
+  font-size: 3rem;
+  letter-spacing: 0.3rem;
+  color: #fff;
+  text-shadow: 0 0 10px rgba(255, 255, 255, 0.8);
+  font-weight: bold;
+  pointer-events: none;
+  z-index: 20;
+  text-transform: uppercase;
+}
+#bottom-text {
+  position: fixed;
+  bottom: 10px;
+  width: 100%;
+  text-align: center;
+  font-size: 0.7rem;
+  color: #fff;
+  pointer-events: none;
+  z-index: 20;
 }
 #scene-container canvas {
   background: #000033;

--- a/index.html
+++ b/index.html
@@ -15,11 +15,13 @@ Change Log:
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <h1 id="cinematic-heading">demos</h1>
   <main>
     <div id="scene-container">
       <div id="fps-counter">0 FPS</div>
     </div>
   </main>
+  <div id="bottom-text">(c) 2025 CyborgsDream</div>
   <script src="https://unpkg.com/three@0.159.0/build/three.min.js"></script>
   <script src="js/script.js"></script>
 </body>

--- a/js/script.js
+++ b/js/script.js
@@ -55,7 +55,7 @@ if (typeof THREE !== 'undefined') {
   const mesh2 = createMesh(new THREE.TorusGeometry(1.2, 0.4, 16, 30), 0x0096D6, 0);
   const mesh3 = createMesh(new THREE.DodecahedronGeometry(1.5), 0x9932cc, 4);
 
-  camera.position.set(0, 6, 10);
+  camera.position.set(0, 5, 8);
   camera.lookAt(0, 1, 0);
 
   let lastTime;


### PR DESCRIPTION
## Summary
- overlay heading and footer text on the page
- move the THREE.js camera closer to the objects
- style new text elements with cinematic feel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883e57547c0832a9b40069219abc1c6