### PR TITLE
Keep overlay text inside the canvas

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -44,7 +44,7 @@ main {
   pointer-events: none;
 }
 #cinematic-heading {
-  position: fixed;
+  position: absolute;
   top: 20px;
   width: 100%;
   text-align: center;
@@ -58,7 +58,7 @@ main {
   text-transform: uppercase;
 }
 #bottom-text {
-  position: fixed;
+  position: absolute;
   bottom: 10px;
   width: 100%;
   text-align: center;

--- a/index.html
+++ b/index.html
@@ -15,13 +15,13 @@ Change Log:
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <h1 id="cinematic-heading">demos</h1>
   <main>
     <div id="scene-container">
+      <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
+      <div id="bottom-text">(c) 2025 CyborgsDream</div>
     </div>
   </main>
-  <div id="bottom-text">(c) 2025 CyborgsDream</div>
   <script src="https://unpkg.com/three@0.159.0/build/three.min.js"></script>
   <script src="js/script.js"></script>
 </body>

--- a/js/script.js
+++ b/js/script.js
@@ -55,7 +55,7 @@ if (typeof THREE !== 'undefined') {
   const mesh2 = createMesh(new THREE.TorusGeometry(1.2, 0.4, 16, 30), 0x0096D6, 0);
   const mesh3 = createMesh(new THREE.DodecahedronGeometry(1.5), 0x9932cc, 4);
 
-  camera.position.set(0, 5, 8);
+  camera.position.set(0, 5, 6);
   camera.lookAt(0, 1, 0);
 
   let lastTime;


### PR DESCRIPTION
## Summary
- place heading and footer elements inside `#scene-container`
- make overlay text absolutely positioned relative to the scene container
- move the camera a bit closer to objects

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6883f0204070832a91e723663c3ab088