### PR TITLE
Add alternating height grid ground

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -14,8 +14,21 @@ if (typeof THREE !== 'undefined') {
   renderer.shadowMap.enabled = true;
   container.appendChild(renderer.domElement);
 
-  // Ground (standard material for debugging visibility)
-  const groundGeo = new THREE.PlaneGeometry(50, 50);
+  // Ground with custom height pattern
+  const groundSize = 32;
+  const groundGeo = new THREE.PlaneGeometry(
+    groundSize,
+    groundSize,
+    groundSize,
+    groundSize
+  );
+  const pos = groundGeo.attributes.position;
+  for (let i = 0; i < pos.count; i++) {
+    const height = i % 2 === 0 ? 0 : -1;
+    pos.setZ(i, height);
+  }
+  groundGeo.computeVertexNormals();
+
   const groundMat = new THREE.MeshStandardMaterial({ color: 0x222222 });
   const ground = new THREE.Mesh(groundGeo, groundMat);
   ground.rotation.x = -Math.PI / 2;


### PR DESCRIPTION
## Summary
- make the ground a 32x32 plane
- set alternating vertex heights between 0 and -1

## Testing
- `pre-commit` *(fails: not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6883fd93a114832a9184e4230ffcbe36