### PR TITLE
Implement 3D heading and center objects

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -60,6 +60,7 @@ main {
   z-index: 20;
   text-transform: uppercase;
   overflow-wrap: anywhere;
+  display: none; /* replaced by 3D text */
 }
 #bottom-text {
   position: absolute;

--- a/index.html
+++ b/index.html
@@ -24,6 +24,8 @@ Change Log:
     </div>
   </main>
   <script src="https://unpkg.com/three@0.159.0/build/three.min.js"></script>
+  <script src="https://unpkg.com/three@0.159.0/examples/js/loaders/FontLoader.js"></script>
+  <script src="https://unpkg.com/three@0.159.0/examples/js/geometries/TextGeometry.js"></script>
   <script src="js/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- hide DOM heading so it can be replaced by a 3D version
- load FontLoader and TextGeometry from Three.js
- make rotating objects smaller and lower them toward the center
- load a 3D text mesh with a sine-wave vertex distortion

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68842f398cb0832a8ce2bdfaabf874af