### PR TITLE
Add console log overlay

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -46,6 +46,23 @@ main {
   pointer-events: none;
   overflow-wrap: anywhere;
 }
+
+#console-log {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  max-height: 100px;
+  overflow-y: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.7);
+  font-family: monospace;
+  font-size: 0.65rem;
+  padding: 2px 4px;
+  pointer-events: none;
+  z-index: 30;
+  overflow-wrap: anywhere;
+}
 #cinematic-heading {
   position: absolute;
   top: 20px;

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
+      <div id="console-log"></div>
       <div id="bottom-text">(c) 2025 CyborgsDream</div>
     </div>
   </main>

--- a/js/script.js
+++ b/js/script.js
@@ -1,6 +1,20 @@
-// Version: 0.0.5
+// Version: 0.0.6
 // Codename: Nebula
 // Basic THREE.js example with multiple objects
+const consoleLogEl = document.getElementById('console-log');
+if (consoleLogEl) {
+  const origLog = console.log;
+  console.log = (...args) => {
+    origLog(...args);
+    const msg = args
+      .map(a => (typeof a === 'object' ? JSON.stringify(a) : String(a)))
+      .join(' ');
+    const line = document.createElement('div');
+    line.textContent = msg;
+    consoleLogEl.appendChild(line);
+    consoleLogEl.scrollTop = consoleLogEl.scrollHeight;
+  };
+}
 console.log('Responsive boilerplate loaded');
 
 // Ensure THREE is available


### PR DESCRIPTION
## Summary
- add console output container in HTML
- style console log overlay
- hook `console.log` in the script to display messages in the overlay

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688435339994832a9c587a5dba8a26ec