### PR TITLE
Fix CDN import for Three.js modules

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -2,8 +2,8 @@
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';
-import { FontLoader } from 'https://unpkg.com/three@0.159.0/examples/jsm/loaders/FontLoader.js';
-import { TextGeometry } from 'https://unpkg.com/three@0.159.0/examples/jsm/geometries/TextGeometry.js';
+import { FontLoader } from 'https://unpkg.com/three@0.159.0/examples/jsm/loaders/FontLoader.js?module';
+import { TextGeometry } from 'https://unpkg.com/three@0.159.0/examples/jsm/geometries/TextGeometry.js?module';
 const consoleLogEl = document.getElementById('console-log');
 if (consoleLogEl) {
   const origLog = console.log;


### PR DESCRIPTION
## Summary
- ensure Three.js example modules load properly by appending `?module` to CDN imports

## Testing
- `npm test` *(fails: missing `package.json`)*
- `pytest`
- `make test` *(fails: no rule `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6884c9726b98832a8577b7c132c5ffa6