### PR TITLE
Fix console log visibility and reposition DEMOS text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -67,8 +67,8 @@ main {
   width: 100%;
   max-height: 100px;
   overflow-y: auto;
-  color: transparent;
-  background: rgba(0, 0, 0, 0.7);
+  color: #0f0;
+  background: transparent;
   font-family: monospace;
   font-size: 0.65rem;
   padding: 2px 4px;
@@ -78,7 +78,7 @@ main {
 }
 
 #console-log .console-line {
-  animation: fade-out 1s ease-out 2s forwards;
+  animation: fade-out 1s ease-out 5s forwards;
 }
 
 @keyframes fade-out {

--- a/js/script.js
+++ b/js/script.js
@@ -20,7 +20,7 @@ if (consoleLogEl) {
       line.textContent = `[${m}] ${msg}`;
       consoleLogEl.appendChild(line);
       consoleLogEl.scrollTop = consoleLogEl.scrollHeight;
-      setTimeout(() => line.remove(), 3000);
+      setTimeout(() => line.remove(), 6000);
     };
   });
 }
@@ -134,7 +134,7 @@ container.appendChild(renderer.domElement);
         textMesh.userData.shader = shader;
       };
       textMesh = new THREE.Mesh(textGeo, textMat);
-      textMesh.position.set(0, 3.5, 0.5);
+      textMesh.position.set(0, 4.2, 0.5);
       textMesh.rotation.x = -Math.PI / 8;
       scene.add(textMesh);
       console.info('3D text added', textMesh.position);


### PR DESCRIPTION
## Summary
- ensure console log text is visible in green
- hide console log background
- extend fade out timing and removal delay
- move 3D DEMOS text slightly upward

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6884ed800c20832ab2a5defeda018bed