### PR TITLE
Implement voxel DEMOS heading and object labels

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/* Version: 0.0.8 */
+/* Version: 0.0.9 */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {
@@ -139,4 +139,12 @@ main {
   main {
     padding: 2rem;
   }
+}
+
+.object-label {
+  position: absolute;
+  pointer-events: none;
+  font-family: monospace;
+  font-size: 0.7rem;
+  text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
 }

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!--
-Version: 0.0.8
+Version: 0.0.9
 Codename: Celestia
 Change Log:
  - Initial responsive boilerplate
@@ -23,7 +23,7 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
-      <div id="version-number">v0.0.8</div>
+      <div id="version-number">v0.0.9</div>
       <div id="console-log"></div>
       <div id="bottom-text">(c) 2025 CyborgsDream</div>
     </div>


### PR DESCRIPTION
## Summary
- bump version to **0.0.9** across files
- replace smooth DEMOS text with voxel-style letters
- display labels under each object showing its name and colour
- add styling for the labels

## Testing
- `node --check js/script.js`


------
https://chatgpt.com/codex/tasks/task_e_6885047aa568832a85777e9bef325a89