### PR TITLE
Use h3 elements for demo object labels

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -153,6 +153,7 @@ main {
 .object-label {
   font-size: 0.7rem;
   color: #fff;
+  margin: 0;
 }
 
 .object-info {

--- a/index.html
+++ b/index.html
@@ -6,9 +6,10 @@ Change Log:
  - Removed welcome header
 - Added cinematic heading and footer text
 - Added version overlay
- - Synced version numbers across files
- - Updated codename
- - Added info text under each object
+- Synced version numbers across files
+- Updated codename
+- Added info text under each object
+- Switched object labels to <h3> elements
 -->
 <!doctype html>
 <html lang="en">

--- a/js/script.js
+++ b/js/script.js
@@ -101,7 +101,7 @@ container.appendChild(renderer.domElement);
 
   const labels = [];
   function addLabel(mesh, text, colorHex, offsetY = -1, className = 'object-label') {
-    const el = document.createElement('div');
+    const el = document.createElement(className === 'object-label' ? 'h3' : 'div');
     el.className = className;
     el.style.color = colorHex;
     el.textContent = text;


### PR DESCRIPTION
## Summary
- use `<h3>` elements instead of `<div>` for object labels so each demo has a heading
- remove default margin from the labels
- document the change in the index comment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885530d3200832ab2f03dbd88f8f705