### PR TITLE
Bump version to 0.0.13beta

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/* Version: 0.0.13alfa */
+/* Version: 0.0.13beta */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!--
-Version: 0.0.13alfa
+Version: 0.0.13beta
 Codename: Celestia
 Change Log:
  - Initial responsive boilerplate
@@ -25,7 +25,7 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
-      <div id="version-number">v0.0.13alfa</div>
+      <div id="version-number">v0.0.13beta</div>
       <div id="console-log"></div>
       <div id="bottom-text">(c) 2025 CyborgsDream</div>
     </div>

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,4 @@
-// Version: 0.0.13alfa
+// Version: 0.0.13beta
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';


### PR DESCRIPTION
## Summary
- bump version numbers in code comments and UI overlay to `v0.0.13beta`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688553fb8008832a9d5a52ba4959e25e