### PR TITLE
Update to v0.0.13ceta with white info text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/* Version: 0.0.13beta */
+/* Version: 0.0.13ceta */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {
@@ -158,5 +158,5 @@ main {
 
 .object-info {
   font-size: 0.55rem;
-  color: #ccc;
+  color: #fff;
 }

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!--
-Version: 0.0.13beta
+Version: 0.0.13ceta
 Codename: Celestia
 Change Log:
  - Initial responsive boilerplate
@@ -10,6 +10,7 @@ Change Log:
 - Updated codename
 - Added info text under each object
 - Switched object labels to <h3> elements
+- Made info text white for visibility
 -->
 <!doctype html>
 <html lang="en">
@@ -25,7 +26,7 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
-      <div id="version-number">v0.0.13beta</div>
+      <div id="version-number">v0.0.13ceta</div>
       <div id="console-log"></div>
       <div id="bottom-text">(c) 2025 CyborgsDream</div>
     </div>

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,4 @@
-// Version: 0.0.13beta
+// Version: 0.0.13ceta
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';
@@ -110,11 +110,11 @@ container.appendChild(renderer.domElement);
   }
 
   addLabel(mesh1, 'Demo One', '#fff');
-  addLabel(mesh1, 'lorem ipsum doloret sit amet', '#ccc', -1.5, 'object-info');
+  addLabel(mesh1, 'lorem ipsum doloret sit amet', '#fff', -1.5, 'object-info');
   addLabel(mesh2, 'Demo Two', '#fff');
-  addLabel(mesh2, 'lorem ipsum doloret sit amet', '#ccc', -1.5, 'object-info');
+  addLabel(mesh2, 'lorem ipsum doloret sit amet', '#fff', -1.5, 'object-info');
   addLabel(mesh3, 'Demo Three', '#fff');
-  addLabel(mesh3, 'lorem ipsum doloret sit amet', '#ccc', -1.5, 'object-info');
+  addLabel(mesh3, 'lorem ipsum doloret sit amet', '#fff', -1.5, 'object-info');
 
   // Chunky voxel-style DEMOS heading
   // Each cube will move with a sinusoidal offset along the Z axis


### PR DESCRIPTION
## Summary
- display object descriptions in white
- bump version numbers to v0.0.13ceta
- document change in the changelog

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68860e44f32c832a8ef8981d0c3a3765