### PR TITLE
Fix overlay text position

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -148,6 +148,8 @@ main {
   font-family: monospace;
   text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
   z-index: 40;
+  left: 0;
+  top: 0;
 }
 
 .object-label {


### PR DESCRIPTION
## Summary
- ensure labels have a defined origin so the info text appears

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688610270b54832ab881eee0eabee276