### PR TITLE
Add 3D waving text planes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -156,6 +156,7 @@ main {
   font-size: 0.7rem;
   color: #fff;
   margin: 0;
+  font-weight: bold;
 }
 
 .object-info {

--- a/js/script.js
+++ b/js/script.js
@@ -139,6 +139,40 @@ container.appendChild(renderer.domElement);
 
   const textCubes = [];
 
+  const textPlanes = [];
+
+  function createTextPlane(text) {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    const fontSize = 64;
+    ctx.font = `bold ${fontSize}px Arial`;
+    const metrics = ctx.measureText(text);
+    canvas.width = metrics.width + 20;
+    canvas.height = fontSize + 20;
+    ctx.font = `bold ${fontSize}px Arial`;
+    ctx.textBaseline = 'top';
+    ctx.fillStyle = '#fff';
+    ctx.fillText(text, 10, 10);
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.minFilter = THREE.LinearFilter;
+    const planeGeo = new THREE.PlaneGeometry(
+      canvas.width / 100,
+      canvas.height / 100,
+      20,
+      5
+    );
+    const planeMat = new THREE.MeshStandardMaterial({
+      map: texture,
+      transparent: true,
+      side: THREE.DoubleSide
+    });
+    const plane = new THREE.Mesh(planeGeo, planeMat);
+    plane.userData.originalPositions = planeGeo.attributes.position.array.slice();
+    plane.userData.phase = Math.random() * Math.PI * 2;
+    textPlanes.push(plane);
+    return plane;
+  }
+
   function createVoxelText(text) {
     const size = 0.4;
     const depth = 0.4;
@@ -203,18 +237,15 @@ container.appendChild(renderer.domElement);
   scene.add(textMesh);
   console.info('Voxel text added', textMesh.position);
 
-  const label1 = createVoxelText('DEMO ONE');
-  label1.scale.set(0.4, 0.4, 0.4);
+  const label1 = createTextPlane('DEMO ONE');
   label1.position.set(mesh1.position.x, 3.2, mesh1.position.z);
   scene.add(label1);
 
-  const label2 = createVoxelText('DEMO TWO');
-  label2.scale.set(0.4, 0.4, 0.4);
+  const label2 = createTextPlane('DEMO TWO');
   label2.position.set(mesh2.position.x, 3.2, mesh2.position.z);
   scene.add(label2);
 
-  const label3 = createVoxelText('DEMO THREE');
-  label3.scale.set(0.4, 0.4, 0.4);
+  const label3 = createTextPlane('DEMO THREE');
   label3.position.set(mesh3.position.x, 3.2, mesh3.position.z);
   scene.add(label3);
   console.info('3D labels added', label1.position, label2.position, label3.position);
@@ -251,6 +282,19 @@ container.appendChild(renderer.domElement);
       cube.position.z = initialZ + Math.sin(timestamp / 500 + phase) * 0.1;
       cube.position.x = initialX + Math.sin(timestamp / 600 + phase) * 0.15;
     });
+    // wave text planes and face the camera
+    textPlanes.forEach(plane => {
+      const posAttr = plane.geometry.attributes.position;
+      const original = plane.userData.originalPositions;
+      for (let i = 0; i < posAttr.count; i++) {
+        const ix = i * 3;
+        const x = original[ix];
+        posAttr.array[ix + 2] =
+          original[ix + 2] + Math.sin(timestamp / 800 + x * 5 + plane.userData.phase) * 0.05;
+      }
+      posAttr.needsUpdate = true;
+      plane.lookAt(camera.position);
+    });
     // update object labels with wind effect and downward offset
     labels.forEach(({ mesh, el, offsetY, phase }) => {
       const pos = mesh.position.clone();
@@ -260,6 +304,9 @@ container.appendChild(renderer.domElement);
       let y = (-pos.y * 0.5 + 0.5) * container.clientHeight;
       const wave = Math.sin(timestamp / 1000 + phase) * 5;
       y += 55 + wave;
+      if (el.classList.contains('object-label')) {
+        y -= 20; // shift object name labels upward
+      }
       // position label so its top aligns with the computed point
       el.style.transform = `translate(-50%, 0) translate(${x}px, ${y}px)`;
     });


### PR DESCRIPTION
## Summary
- make object name labels bold
- shift object name labels up 20px
- render DEMO labels as textured planes that wave in 3D

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886197a4a1c832a9d0744ee72c5abf8