### PR TITLE
Update visuals and bump version to 0.0.14b

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/* Version: 0.0.14a */
+/* Version: 0.0.14b */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {
@@ -80,6 +80,7 @@ main {
 
 #console-log .console-line {
   background: none;
+  opacity: 0.5;
   animation: fade-out 0.5s ease-out 2.5s forwards;
 }
 
@@ -147,7 +148,7 @@ main {
   position: absolute;
   pointer-events: none;
   font-family: monospace;
-  text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   z-index: 40;
   left: 0;
   top: 0;

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!--
-Version: 0.0.14a
+Version: 0.0.14b
 Codename: Celestia
 Change Log:
  - Initial responsive boilerplate
@@ -11,8 +11,10 @@ Change Log:
 - Added info text under each object
 - Switched object labels to <h3> elements
  - Made info text white for visibility
- - Removed console log background and limited visibility to 3 seconds
- - Bumped version to 0.0.14a
+- Removed console log background and limited visibility to 3 seconds
+- Bumped version to 0.0.14b
+- Raised demo objects and enabled inter-object shadows
+- Set console log text to 50% opacity
 -->
 <!doctype html>
 <html lang="en">
@@ -28,7 +30,7 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
-      <div id="version-number">v0.0.14a</div>
+      <div id="version-number">v0.0.14b</div>
       <div id="console-log"></div>
       <div id="bottom-text">(c) 2025 CyborgsDream</div>
     </div>

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,4 @@
-// Version: 0.0.14a
+// Version: 0.0.14b
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';
@@ -88,8 +88,9 @@ container.appendChild(renderer.domElement);
   function createMesh(geometry, color, x, z = 1) {
     const material = new THREE.MeshStandardMaterial({ color });
     const mesh = new THREE.Mesh(geometry, material);
-    mesh.position.set(x, 1.5, z); // lowered to center objects
+    mesh.position.set(x, 2, z); // raised slightly
     mesh.castShadow = true;
+    mesh.receiveShadow = true;
     scene.add(mesh);
     return mesh;
   }


### PR DESCRIPTION
## Summary
- bump version to **0.0.14b**
- raise demo meshes slightly and let them receive shadows
- tone down console log text opacity
- adjust label drop shadow

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688625c2a018832a9c149f9435b2973c