### PR TITLE
Refine DEMOS text wave and bump version

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/* Version: 0.0.14b */
+/* Version: 0.0.14c */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!--
-Version: 0.0.14b
+Version: 0.0.14c
 Codename: Celestia
 Change Log:
  - Initial responsive boilerplate
@@ -12,7 +12,8 @@ Change Log:
 - Switched object labels to <h3> elements
  - Made info text white for visibility
 - Removed console log background and limited visibility to 3 seconds
-- Bumped version to 0.0.14b
+ - Bumped version to 0.0.14c
+ - Reduced DEMOS text wave range and limited movement to Z axis
 - Raised demo objects and enabled inter-object shadows
 - Set console log text to 50% opacity
 -->
@@ -30,7 +31,7 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
-      <div id="version-number">v0.0.14b</div>
+      <div id="version-number">v0.0.14c</div>
       <div id="console-log"></div>
       <div id="bottom-text">(c) 2025 CyborgsDream</div>
     </div>

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,4 @@
-// Version: 0.0.14b
+// Version: 0.0.14c
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';
@@ -154,6 +154,7 @@ container.appendChild(renderer.domElement);
   };
 
   const textCubes = [];
+  const textLetters = [];
 
 
   function createVoxelText(text) {
@@ -205,11 +206,16 @@ container.appendChild(renderer.domElement);
       });
       letterGroup.position.x = offsetX + letterWidth / 2;
       group.add(letterGroup);
+      textLetters.push(letterGroup);
       offsetX += letterWidth + size;
     });
     const box = new THREE.Box3().setFromObject(group);
     const center = box.getCenter(new THREE.Vector3());
     group.children.forEach(c => c.position.sub(center));
+    textLetters.forEach(letter => {
+      letter.userData.initialZ = letter.position.z;
+      letter.userData.phase = Math.random() * Math.PI * 2;
+    });
     group.scale.set(2 / 3, 2 / 3, 2 / 3);
     group.position.set(0, 4.35, 0.5);
     group.rotation.x = 0; // face the camera directly
@@ -248,11 +254,10 @@ container.appendChild(renderer.domElement);
       cube.rotation.y += rotSpeed.y;
       cube.rotation.z += rotSpeed.z;
     });
-    // apply wind effect to each text cube
-    textCubes.forEach(cube => {
-      const { initialX, initialZ, phase } = cube.userData;
-      cube.position.z = initialZ + Math.sin(timestamp / 500 + phase) * 0.1;
-      cube.position.x = initialX + Math.sin(timestamp / 600 + phase) * 0.15;
+    // apply wave effect to each letter group
+    textLetters.forEach(letter => {
+      const { initialZ, phase } = letter.userData;
+      letter.position.z = initialZ + Math.sin(timestamp / 600 + phase) * 0.05;
     });
     // update object labels with wind effect and downward offset
     labels.forEach(({ mesh, el, offsetY, phase, letters }) => {


### PR DESCRIPTION
## Summary
- bump version to 0.0.14c
- animate DEMOS letters only on Z axis with smaller wave

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688629c2c094832ab624bea7d1b39d0b