### PR TITLE
Update to v0.0.14d and tweak demo popup

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/* Version: 0.0.14c */
+/* Version: 0.0.14d */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {
@@ -174,12 +174,21 @@ main {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background: rgba(0, 0, 0, 0.8);
+  background: rgba(0, 0, 0, 0.6);
   color: #fff;
-  padding: 1rem;
-  max-width: 300px;
+  padding: 1.5rem;
+  max-width: 400px;
   text-align: center;
   z-index: 50;
+}
+
+#demo-info .close-icon {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  cursor: pointer;
+  font-size: 1.2rem;
+  opacity: 0.8;
 }
 
 #demo-info button {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!--
-Version: 0.0.14c
+Version: 0.0.14d
 Codename: Celestia
 Change Log:
  - Initial responsive boilerplate
@@ -12,7 +12,7 @@ Change Log:
 - Switched object labels to <h3> elements
  - Made info text white for visibility
 - Removed console log background and limited visibility to 3 seconds
- - Bumped version to 0.0.14c
+ - Bumped version to 0.0.14d
  - Reduced DEMOS text wave range and limited movement to Z axis
 - Raised demo objects and enabled inter-object shadows
 - Set console log text to 50% opacity
@@ -31,9 +31,10 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
-      <div id="version-number">v0.0.14c</div>
+      <div id="version-number">v0.0.14d</div>
       <div id="console-log"></div>
       <div id="demo-info" style="display:none">
+        <span id="close-info" class="close-icon" aria-label="Close">&times;</span>
         <h2></h2>
         <p></p>
         <button id="run-demo">Run Demo</button>

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,4 @@
-// Version: 0.0.14c
+// Version: 0.0.14d
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';
@@ -147,6 +147,7 @@ container.appendChild(renderer.domElement);
   const infoTitle = infoBox.querySelector('h2');
   const infoText = infoBox.querySelector('p');
   const runBtn = document.getElementById('run-demo');
+  const closeBtn = document.getElementById('close-info');
   const raycaster = new THREE.Raycaster();
   const mouse = new THREE.Vector2();
   function selectDemo(index) {
@@ -166,6 +167,15 @@ container.appendChild(renderer.domElement);
     runBtn.onclick = () => (window.location.href = data.file);
     infoBox.style.display = 'block';
   }
+
+  closeBtn.addEventListener('click', () => {
+    infoBox.style.display = 'none';
+    meshes.forEach(m => {
+      m.scale.set(1, 1, 1);
+      m.material.opacity = 1;
+      m.material.transparent = false;
+    });
+  });
 
   function onPick(event) {
     const rect = renderer.domElement.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- bump version numbers to **0.0.14d**
- enlarge and lighten the demo info popup
- add a close icon for dismissing the popup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688634804db4832aa4def8b682d2333d