### PR TITLE
Improve demo info display

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -182,6 +182,14 @@ main {
   z-index: 50;
   border-radius: 8px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  display: none;
+  opacity: 0;
+  transition: opacity 1s;
+}
+
+#demo-info.visible {
+  display: block;
+  opacity: 1;
 }
 
 #demo-info .close-icon {

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@ Change Log:
       <div id="fps-counter">0 FPS</div>
       <div id="version-number">v0.0.14e</div>
       <div id="console-log"></div>
-      <div id="demo-info" style="display:none">
+      <div id="demo-info">
         <span id="close-info" class="close-icon" aria-label="Close">&times;</span>
         <h2></h2>
         <p></p>

--- a/js/script.js
+++ b/js/script.js
@@ -148,6 +148,7 @@ container.appendChild(renderer.domElement);
   const infoText = infoBox.querySelector('p');
   const runBtn = document.getElementById('run-demo');
   const closeBtn = document.getElementById('close-info');
+  let ignoreNextContainerClick = false;
   const raycaster = new THREE.Raycaster();
   const mouse = new THREE.Vector2();
   function selectDemo(index) {
@@ -166,10 +167,15 @@ container.appendChild(renderer.domElement);
     infoText.textContent = data.long;
     runBtn.onclick = () => (window.location.href = data.file);
     infoBox.style.display = 'block';
+    requestAnimationFrame(() => infoBox.classList.add('visible'));
+    ignoreNextContainerClick = true;
   }
 
   function hideDemoInfo() {
-    infoBox.style.display = 'none';
+    infoBox.classList.remove('visible');
+    setTimeout(() => {
+      infoBox.style.display = 'none';
+    }, 1000);
     meshes.forEach(m => {
       m.scale.set(1, 1, 1);
       m.material.opacity = 1;
@@ -179,6 +185,10 @@ container.appendChild(renderer.domElement);
 
   closeBtn.addEventListener('click', hideDemoInfo);
   container.addEventListener('click', e => {
+    if (ignoreNextContainerClick) {
+      ignoreNextContainerClick = false;
+      return;
+    }
     if (infoBox.style.display === 'block' && !infoBox.contains(e.target)) {
       hideDemoInfo();
     }


### PR DESCRIPTION
## Summary
- fix info panel closing immediately on object click
- add fade in/out animation for the demo info panel
- update HTML to work with new CSS classes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688638cb110c832a9f14296c2324ce8a