### PR TITLE
Bump demo version to 0.0.14g

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/* Version: 0.0.14f */
+/* Version: 0.0.14g */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!--
-Version: 0.0.14f
+Version: 0.0.14g
 Codename: Celestia
 Change Log:
  - Initial responsive boilerplate
@@ -12,7 +12,7 @@ Change Log:
 - Switched object labels to <h3> elements
  - Made info text white for visibility
 - Removed console log background and limited visibility to 3 seconds
- - Bumped version to 0.0.14f
+ - Bumped version to 0.0.14g
  - Reduced DEMOS text wave range and limited movement to Z axis
 - Raised demo objects and enabled inter-object shadows
 - Set console log text to 50% opacity
@@ -32,7 +32,7 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
-      <div id="version-number">v0.0.14f</div>
+      <div id="version-number">v0.0.14g</div>
       <div id="console-log"></div>
       <div id="demo-info">
         <span id="close-info" class="close-icon" aria-label="Close">&times;</span>

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,4 @@
-// Version: 0.0.14f
+// Version: 0.0.14g
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';


### PR DESCRIPTION
## Summary
- bump CSS, JS and HTML version strings to v0.0.14g

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688641d85afc832a9182c0c0c19d502d