### PR TITLE
Rename demos to apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Running the demos locally
+# Running the apps locally
 
 To avoid browser CORS restrictions when loading the ES module in `script.js`, start a simple HTTP server from the repository root:
 

--- a/css/style.css
+++ b/css/style.css
@@ -169,7 +169,7 @@ main {
   color: #fff;
 }
 
-#demo-info {
+#app-info {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -187,12 +187,12 @@ main {
   transition: opacity 1s;
 }
 
-#demo-info.visible {
+#app-info.visible {
   display: block;
   opacity: 1;
 }
 
-#demo-info .close-icon {
+#app-info .close-icon {
   position: absolute;
   top: 5px;
   right: 5px;
@@ -202,21 +202,21 @@ main {
   transition: transform 0.1s, opacity 0.1s;
 }
 
-#demo-info .close-icon:hover {
+#app-info .close-icon:hover {
   opacity: 1;
 }
 
-#demo-info .close-icon:active {
+#app-info .close-icon:active {
   transform: scale(0.9);
 }
 
-#demo-info button {
+#app-info button {
   margin-top: 0.5rem;
   padding: 0.25rem 0.5rem;
   cursor: pointer;
   transition: transform 0.1s;
 }
 
-#demo-info button:active {
+#app-info button:active {
   transform: scale(0.95);
 }

--- a/data/index.json
+++ b/data/index.json
@@ -1,5 +1,5 @@
 {
-  "demos": [
+  "apps": [
     {
       "name": "Demo One",
       "file": "demo1.html",

--- a/index.html
+++ b/index.html
@@ -30,15 +30,15 @@ Change Log:
 <body>
   <main>
     <div id="scene-container">
-      <h1 id="cinematic-heading">demos</h1>
+      <h1 id="cinematic-heading">apps</h1>
       <div id="fps-counter">0 FPS</div>
       <div id="version-number">v0.0.14h</div>
       <div id="console-log"></div>
-      <div id="demo-info">
+      <div id="app-info">
         <span id="close-info" class="close-icon" aria-label="Close">&times;</span>
         <h2></h2>
         <p></p>
-        <button id="run-demo">Run Demo</button>
+        <button id="run-app">Run App</button>
       </div>
       <div id="bottom-text">(c) 2025 CyborgsDream</div>
     </div>

--- a/js/script.js
+++ b/js/script.js
@@ -2,7 +2,7 @@
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';
-const { demos } = await fetch('data/index.json').then(r => r.json());
+const { apps } = await fetch('data/index.json').then(r => r.json());
 const consoleLogEl = document.getElementById('console-log');
 if (consoleLogEl) {
   const methods = ['log', 'info', 'warn', 'error'];
@@ -135,24 +135,24 @@ container.appendChild(renderer.domElement);
   }
 
   const offsets = [-20, 0, 20];
-  demos.forEach((demo, i) => {
+  apps.forEach((app, i) => {
     const mesh = meshes[i];
     if (!mesh) return;
     const off = offsets[i] || 0;
-    addLabel(mesh, demo.name, '#fff', -1, 'object-label', off);
-    addLabel(mesh, demo.short, '#fff', -1.5, 'object-info', off);
+    addLabel(mesh, app.name, '#fff', -1, 'object-label', off);
+    addLabel(mesh, app.short, '#fff', -1.5, 'object-info', off);
   });
 
-  const infoBox = document.getElementById('demo-info');
+  const infoBox = document.getElementById('app-info');
   const infoTitle = infoBox.querySelector('h2');
   const infoText = infoBox.querySelector('p');
-  const runBtn = document.getElementById('run-demo');
+  const runBtn = document.getElementById('run-app');
   const closeBtn = document.getElementById('close-info');
   let ignoreNextContainerClick = false;
   const raycaster = new THREE.Raycaster();
   const mouse = new THREE.Vector2();
-  function selectDemo(index) {
-    const data = demos[index];
+  function selectApp(index) {
+    const data = apps[index];
     meshes.forEach((m, i) => {
       m.material.transparent = true;
       if (i === index) {
@@ -178,7 +178,7 @@ container.appendChild(renderer.domElement);
     ignoreNextContainerClick = true;
   }
 
-  function hideDemoInfo() {
+  function hideAppInfo() {
     infoBox.classList.remove('visible');
     setTimeout(() => {
       infoBox.style.display = 'none';
@@ -190,18 +190,18 @@ container.appendChild(renderer.domElement);
     });
   }
 
-  closeBtn.addEventListener('pointerdown', hideDemoInfo);
+  closeBtn.addEventListener('pointerdown', hideAppInfo);
   container.addEventListener('pointerdown', e => {
     if (ignoreNextContainerClick) {
       ignoreNextContainerClick = false;
       return;
     }
     if (infoBox.style.display === 'block' && !infoBox.contains(e.target)) {
-      hideDemoInfo();
+      hideAppInfo();
     }
   });
   window.addEventListener('keydown', e => {
-    if (e.key === 'Escape' && infoBox.style.display === 'block') hideDemoInfo();
+    if (e.key === 'Escape' && infoBox.style.display === 'block') hideAppInfo();
   });
 
   function onPick(event) {
@@ -210,12 +210,12 @@ container.appendChild(renderer.domElement);
     mouse.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
     raycaster.setFromCamera(mouse, camera);
     const hit = raycaster.intersectObjects(meshes);
-    if (hit.length) selectDemo(meshes.indexOf(hit[0].object));
+    if (hit.length) selectApp(meshes.indexOf(hit[0].object));
   }
 
   renderer.domElement.addEventListener('pointerdown', onPick);
 
-  // Chunky voxel-style DEMOS heading
+  // Chunky voxel-style APPS heading
   // Each cube will move with a sinusoidal offset along the Z axis
   const LETTERS = {
     D: ['11110', '10001', '10001', '10001', '10001', '10001', '11110'],
@@ -299,7 +299,7 @@ container.appendChild(renderer.domElement);
     return group;
   }
 
-  const textMesh = createVoxelText('DEMOS');
+  const textMesh = createVoxelText('APPS');
   scene.add(textMesh);
   console.info('Voxel text added', textMesh.position);
 


### PR DESCRIPTION
## Summary
- rename `demos` data key to `apps`
- update `script.js` to read from `apps` and rename DOM ids
- rename info overlay ids/classes in styles
- update heading and button text in index.html
- adjust README wording

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68864dff2204832aa3e04679d5ac529e