### PR TITLE
Fix 3D heading display

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ Change Log:
 <body>
   <main>
     <div id="scene-container">
-      <h1 id="cinematic-heading">apps</h1>
+      <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
       <div id="version-number">v0.0.14.h</div>
       <div id="console-log"></div>

--- a/js/script.js
+++ b/js/script.js
@@ -215,7 +215,7 @@ container.appendChild(renderer.domElement);
 
   renderer.domElement.addEventListener('pointerdown', onPick);
 
-  // Chunky voxel-style APPS heading
+  // Chunky voxel-style DEMOS heading
   // Each cube will move with a sinusoidal offset along the Z axis
   const LETTERS = {
     D: ['11110', '10001', '10001', '10001', '10001', '10001', '11110'],
@@ -299,7 +299,7 @@ container.appendChild(renderer.domElement);
     return group;
   }
 
-  const textMesh = createVoxelText('APPS');
+  const textMesh = createVoxelText('DEMOS');
   scene.add(textMesh);
   console.info('Voxel text added', textMesh.position);
 


### PR DESCRIPTION
## Summary
- display `DEMOS` instead of `APPS`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68865049231c832aae0f942a3fce317e