### PR TITLE
Fix local CORS issue and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # Running the apps locally
 
-To avoid browser CORS restrictions when loading the ES module in `script.js`, start a simple HTTP server from the repository root:
+To avoid browser CORS restrictions when loading files like `script.js`, start a simple HTTP server from the repository root.
+You can use Python or Node:
 
 ```bash
 python3 -m http.server
 ```
+
+# or using Node
+node server.js
 
 Then open <http://localhost:8000/index.html> in your browser.

--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/* Version: 0.0.14.k */
+/* Version: 0.0.14k-alfa */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!--
-Version: 0.0.14.k
+Version: 0.0.14k-alfa
 Codename: Celestia
 Change Log:
  - Initial responsive boilerplate
@@ -12,7 +12,7 @@ Change Log:
 - Switched object labels to <h3> elements
  - Made info text white for visibility
 - Removed console log background and limited visibility to 3 seconds
- - Bumped version to 0.0.14.k
+ - Bumped version to 0.0.14k-alfa
  - Reduced DEMOS text wave range and limited movement to Z axis
 - Raised demo objects and enabled inter-object shadows
 - Set console log text to 50% opacity
@@ -32,7 +32,7 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
-      <div id="version-number">v0.0.14.k</div>
+      <div id="version-number">v0.0.14k-alfa</div>
       <div id="console-log"></div>
       <div id="app-info">
         <span id="close-info" class="close-icon" aria-label="Close">&times;</span>
@@ -43,6 +43,11 @@ Change Log:
       <div id="bottom-text">(c) 2025 CyborgsDream</div>
     </div>
   </main>
+  <script>
+    if (location.protocol === 'file:') {
+      alert('Run a local server (python3 -m http.server or node server.js) and open http://localhost:8000/index.html');
+    }
+  </script>
   <script type="module" src="js/script.js"></script>
 </body>
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,4 @@
-// Version: 0.0.14.k
+// Version: 0.0.14k-alfa
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';

--- a/server.js
+++ b/server.js
@@ -1,0 +1,35 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 8000;
+const root = path.resolve(__dirname);
+
+const mime = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.gif': 'image/gif'
+};
+
+http.createServer((req, res) => {
+  let filePath = path.join(root, decodeURI(req.url));
+  if (req.url === '/' || req.url === '') {
+    filePath = path.join(root, 'index.html');
+  }
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    const ext = path.extname(filePath);
+    res.writeHead(200, { 'Content-Type': mime[ext] || 'application/octet-stream' });
+    res.end(data);
+  });
+}).listen(port, () => {
+  console.log(`Server running at http://localhost:${port}/`);
+});


### PR DESCRIPTION
## Summary
- bump version to 0.0.14k-alfa across the app
- add helper `server.js` for running a simple local HTTP server
- document running with Python or Node in README
- show an alert if the page is opened using the `file:` protocol

## Testing
- `node server.js` *(started and printed server message)*
- `python3 -m http.server` *(started successfully)*


------
https://chatgpt.com/codex/tasks/task_e_688654aeab9c832ab65fea57e0026dde