### PR TITLE
Fix landscape cut off by using dynamic viewport units

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -12,7 +12,7 @@ body {
   line-height: 1.6;
   color: #333;
   background: #000;
-  min-height: 100vh;
+  min-height: calc(var(--vh, 1vh) * 100);
   display: flex;
   flex-direction: column;
   position: relative;

--- a/js/script.js
+++ b/js/script.js
@@ -388,6 +388,12 @@ container.appendChild(renderer.domElement);
   window.addEventListener('resize', onWindowResize);
   window.addEventListener('orientationchange', checkOrientation);
   window.addEventListener('pointerup', checkOrientation);
+  function updateViewportHeight() {
+    document.documentElement.style.setProperty('--vh', `${window.innerHeight * 0.01}px`);
+  }
+  window.addEventListener('resize', updateViewportHeight);
+  window.addEventListener('orientationchange', updateViewportHeight);
+  updateViewportHeight();
   onWindowResize();
   checkOrientation();
 


### PR DESCRIPTION
## Summary
- fix page cropping in landscape orientation by using dynamic viewport height units
- update responsive script to maintain `--vh` CSS variable on resize/orientation changes

## Testing
- `node --check js/script.js`

------
https://chatgpt.com/codex/tasks/task_e_68866294add4832a871b42577499e3d9