### PR TITLE
Modularize demo apps

### DIFF
--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -605,7 +605,7 @@
             icons.forEach(icon => {
                 const el = document.createElement('div');
                 el.className = 'icon';
-                if (icon.type) el.setAttribute('onclick', `openWindow('${icon.type}')`);
+                if (icon.type) el.setAttribute('onclick', `loadApp('${icon.label.toLowerCase()}')`);
                 el.innerHTML = `<div class="icon-image">${icon.emoji}</div><div class="icon-label">${icon.label}</div>`;
                 container.appendChild(el);
             });
@@ -995,5 +995,6 @@
 
         window.onload = init;
     </script>
+    <script src="app-js/gui-api.js"></script>
 </body>
 </html>

--- a/apps/app1/app-js/calculator.js
+++ b/apps/app1/app-js/calculator.js
@@ -1,0 +1,1 @@
+WinAPI.createWindow('calculator');

--- a/apps/app1/app-js/calendar.js
+++ b/apps/app1/app-js/calendar.js
@@ -1,0 +1,1 @@
+WinAPI.createWindow('calendar');

--- a/apps/app1/app-js/games.js
+++ b/apps/app1/app-js/games.js
@@ -1,0 +1,1 @@
+WinAPI.createWindow('games');

--- a/apps/app1/app-js/gui-api.js
+++ b/apps/app1/app-js/gui-api.js
@@ -1,0 +1,20 @@
+(function(){
+    function loadApp(name){
+        const script=document.createElement('script');
+        script.src=`app-js/${name}.js`;
+        document.body.appendChild(script);
+    }
+    function createWindow(type){
+        if(window.openWindow) window.openWindow(type);
+    }
+    function closeWin(id){ if(window.closeWindow) window.closeWindow(id); }
+    function minimizeWin(id){ if(window.minimizeWindow) window.minimizeWindow(id); }
+    function maximizeWin(id){ if(window.maximizeWindow) window.maximizeWindow(id); }
+    window.loadApp=loadApp;
+    window.WinAPI={
+        createWindow,
+        closeWindow:closeWin,
+        minimizeWindow:minimizeWin,
+        maximizeWindow:maximizeWin
+    };
+})();

--- a/apps/app1/app-js/paint.js
+++ b/apps/app1/app-js/paint.js
@@ -1,0 +1,1 @@
+WinAPI.createWindow('graphics');

--- a/apps/app1/app-js/puzzle.js
+++ b/apps/app1/app-js/puzzle.js
@@ -1,0 +1,1 @@
+WinAPI.createWindow('puzzle-game');

--- a/apps/app1/app-js/system.js
+++ b/apps/app1/app-js/system.js
@@ -1,0 +1,1 @@
+WinAPI.createWindow('system-info');

--- a/apps/app1/app-js/terminal.js
+++ b/apps/app1/app-js/terminal.js
@@ -1,0 +1,1 @@
+WinAPI.createWindow('terminal');

--- a/apps/app1/app-js/textedit.js
+++ b/apps/app1/app-js/textedit.js
@@ -1,0 +1,1 @@
+WinAPI.createWindow('text-editor');

--- a/apps/app1/app-js/utilities.js
+++ b/apps/app1/app-js/utilities.js
@@ -1,0 +1,1 @@
+WinAPI.createWindow('utilities');

--- a/data/index.json
+++ b/data/index.json
@@ -2,7 +2,7 @@
   "apps": [
     {
       "name": "Demo One",
-      "file": "apps/app1/index.html",
+      "file": "apps/app1/app-index.html",
       "short": "lorem ipsum doloret sit amet",
       "long": "This is the first demo showcasing features."
     },


### PR DESCRIPTION
## Summary
- rename `apps/app1/index.html` to `app-index.html`
- update demo paths
- add Windows-style GUI API library
- load app JS modules per icon
- add JS files for each mini app

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68866927f51c832a8cb15d58d51b2bbf