### PR TITLE
Fix icon handlers and rename demo

### DIFF
--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -605,8 +605,12 @@
             icons.forEach(icon => {
                 const el = document.createElement('div');
                 el.className = 'icon';
-                if (icon.type) el.setAttribute('onclick', `loadApp('${icon.label.toLowerCase()}')`);
                 el.innerHTML = `<div class="icon-image">${icon.emoji}</div><div class="icon-label">${icon.label}</div>`;
+                if (icon.type) {
+                    const handler = () => loadApp(icon.label.toLowerCase());
+                    el.addEventListener('click', handler);
+                    el.addEventListener('touchstart', handler);
+                }
                 container.appendChild(el);
             });
         }

--- a/data/index.json
+++ b/data/index.json
@@ -1,7 +1,7 @@
 {
   "apps": [
     {
-      "name": "Demo One",
+      "name": "WebGUI",
       "file": "apps/app1/app-index.html",
       "short": "lorem ipsum doloret sit amet",
       "long": "This is the first demo showcasing features."


### PR DESCRIPTION
## Summary
- make app1 desktop icons use event listeners instead of inline handlers
- rename demo one to WebGUI in index data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68866dff0f84832aae243f262dec4458