### PR TITLE
Fix duplicate window opening on touch devices

### DIFF
--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -613,7 +613,6 @@
                         if (now - lastIconTouch < 1000) return;
                         lastIconTouch = now;
                         if (e.type === 'touchstart') e.preventDefault();
-                        openWindow(icon.type);
                         loadApp(icon.label.toLowerCase());
                     };
                     el.addEventListener('click', handler);


### PR DESCRIPTION
## Summary
- stop calling `openWindow` when icons are touched

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688686ede074832a8fb6171d44ec514e