### PR TITLE
Improve clock locale

### DIFF
--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -665,14 +665,15 @@
         }
         
         // Clock functionality
-        function initClock() {
+        function initClock(format) {
             let use24 = false;
             const clockEl = document.getElementById('clock');
+            const locale = format || navigator.language || 'en-US';
 
             function updateClock() {
                 const now = new Date();
                 const opts = { hour12: !use24 };
-                clockEl.textContent = now.toLocaleTimeString('en-US', opts);
+                clockEl.textContent = now.toLocaleTimeString(locale, opts);
             }
 
             function toggle() {
@@ -840,7 +841,7 @@
             buildIcons(appData.icons);
             document.getElementById('status-bar').textContent = appData.status;
             buildWelcome(appData.welcome);
-            initClock();
+            initClock(appData.settings && appData.settings.clockFormat);
             initMenus();
             updateTaskBar();
         }

--- a/apps/app1/app-js/clock.js
+++ b/apps/app1/app-js/clock.js
@@ -1,7 +1,13 @@
 WinAPI.createWindow('clock');
+
+function getClockLocale() {
+    const data = window.appData || {};
+    return (data.settings && data.settings.clockFormat) || navigator.language || 'en-US';
+}
+
 setInterval(() => {
     const el = document.getElementById('live-clock');
     if (el) {
-        el.textContent = new Date().toLocaleTimeString();
+        el.textContent = new Date().toLocaleTimeString(getClockLocale());
     }
 }, 1000);


### PR DESCRIPTION
## Summary
- read optional `clockFormat` from settings
- use custom locale in the clock widget

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68868fc612cc832a9066e74aaacd33c3