### PR TITLE
Fix HTML Studio preview and update version to 0.0.17

### DIFF
--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -41,10 +41,10 @@
   ],
   "status": "Icons are now clickable! Click any icon to open an application.",
   "welcome": {
-    "title": "WebGUI 0.0.16beta",
+    "title": "WebGUI 0.0.17",
     "lines": [
       "Welcome to WebGUI - Web browser based windows GUI",
-      "Version 0.0.16beta",
+      "Version 0.0.17",
       "(c) 2025 CyborgsDream"
     ],
     "button": "OK"
@@ -68,7 +68,7 @@
   "windows": {
     "system-info": {
       "title": "System Information",
-      "content": "<h2>WebGUI Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>WebGUI 0.0.16beta</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Power Without the Price</div></div>",
+      "content": "<h2>WebGUI Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>WebGUI 0.0.17</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Power Without the Price</div></div>",
       "width": 320,
       "height": 300
     },
@@ -80,7 +80,7 @@
     },
     "text-editor": {
       "title": "Text Editor",
-      "content": "<textarea style=\"width: 100%; height: 100%; background: #fff; border: 1px solid #aaa; padding: 5px; font-family: monospace; font-size: 18px;\">Welcome to WebGUI 0.0.16beta!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea>",
+      "content": "<textarea style=\"width: 100%; height: 100%; background: #fff; border: 1px solid #aaa; padding: 5px; font-family: monospace; font-size: 18px;\">Welcome to WebGUI 0.0.17!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea>",
       "width": 500,
       "height": 350
     },

--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>WebGUI 0.0.16beta</title>
+    <title>WebGUI 0.0.17</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=VT323&display=swap">
     <style>
         * {

--- a/apps/app1/html-studio.html
+++ b/apps/app1/html-studio.html
@@ -65,7 +65,15 @@ document.getElementById('closeBtn').onclick=()=>{
 };
 const template=pretty(`<!doctype html><html><head><meta charset="utf-8"><title>Demo</title><style>body{font-family:sans-serif;padding:2rem}</style></head><body><h1>Hello!</h1><p>Edit code or <em>WYSIWYG</em>.</p></body></html>`);
 const LS='studio-snaps',load=()=>JSON.parse(localStorage.getItem(LS)||'[]'),save=a=>localStorage.setItem(LS,JSON.stringify(a));
-const sync=()=>{const c=editor.getValue();$('preview').srcdoc=c;$('sizeInfo').textContent='size:'+c.length+'c';};
+function setupPreview(){
+  const doc=$('preview').contentDocument;
+  if(!doc||doc.__init)return;
+  doc.designMode='on';
+  $('wys').onclick=e=>{const cmd=e.target.dataset.cmd;if(!cmd)return;const arg=cmd==='createLink'?prompt('URL','https://'):e.target.dataset.arg||null;doc.execCommand(cmd,false,arg);};
+  doc.addEventListener('input',()=>{editor.setValue(pretty(doc.documentElement.outerHTML));sync(false);});
+  doc.__init=true;
+}
+function sync(update=true){const c=editor.getValue();if(update){$('preview').srcdoc=c;setTimeout(setupPreview);}$('sizeInfo').textContent='size:'+c.length+'c';}
 require.config({paths:{vs:'https://cdn.jsdelivr.net/npm/monaco-editor@0.41.0/min/vs'}});
 let fallbackTO=setTimeout(useTA,5000);
 require(['vs/editor/editor.main'],()=>{clearTimeout(fallbackTO);editor=monaco.editor.create($('editor'),{value:template,language:'html',theme:'vs-dark',automaticLayout:true,minimap:{enabled:false}});editor.onDidChangeModelContent(sync);sync();ui();log('Monaco ready');});
@@ -80,11 +88,7 @@ function ui(){
   $('codeBtn').onclick =()=>setView('codeBtn');
   $('splitBtn').onclick=()=>setView('splitBtn');
   $('wysBtn').onclick  =()=>setView('wysBtn');
-  $('preview').addEventListener('load',()=>{
-    const doc=$('preview').contentDocument;doc.designMode='on';
-    $('wys').onclick=e=>{const cmd=e.target.dataset.cmd;if(!cmd)return;const arg=cmd==='createLink'?prompt('URL','https://'):e.target.dataset.arg||null;doc.execCommand(cmd,false,arg);};
-    doc.addEventListener('input',()=>{editor.setValue(pretty(doc.documentElement.outerHTML));sync();});
-  });
+  setupPreview();
   const refill=()=>{$('verInfo').textContent='ver:'+load().length;$('loadSel').innerHTML='<option disabled selected>Load…</option>';load().slice().reverse().forEach(v=>{const o=document.createElement('option');o.value=v.id;o.textContent=new Date(v.id).toLocaleString();$('loadSel').appendChild(o);});};
   $('saveBtn').onclick=()=>{const a=load();a.push({id:Date.now(),code:editor.getValue()});save(a);refill();log('saved');};
   $('loadSel').onchange=e=>{const s=load().find(v=>v.id==e.target.value);if(s){editor.setValue(pretty(s.code));sync();}e.target.value='';};

--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/* Version: 0.0.16beta */
+/* Version: 0.0.17 */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!--
-Version: 0.0.16beta
+Version: 0.0.17
 Codename: Celestia
 Change Log:
  - Initial responsive boilerplate
@@ -12,7 +12,7 @@ Change Log:
 - Switched object labels to <h3> elements
  - Made info text white for visibility
 - Removed console log background and limited visibility to 3 seconds
- - Bumped version to 0.0.16beta
+ - Bumped version to 0.0.17
  - Reduced DEMOS text wave range and limited movement to Z axis
 - Raised demo objects and enabled inter-object shadows
 - Set console log text to 50% opacity
@@ -32,7 +32,7 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
-      <div id="version-number">v0.0.16beta</div>
+      <div id="version-number">v0.0.17</div>
       <div id="console-log"></div>
       <div id="app-info">
         <span id="close-info" class="close-icon" aria-label="Close">&times;</span>

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,4 @@
-// Version: 0.0.16beta
+// Version: 0.0.17
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';


### PR DESCRIPTION
## Summary
- make HTML Studio preview initialize reliably
- bump version numbers to 0.0.17 across the project

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688699e55100832aad3b03b658e9d0b7