### PR TITLE
Add cloud storage app and restyle HTML Studio

### DIFF
--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -63,7 +63,8 @@
     {"type": "docs", "emoji": "📖", "label": "Docs"},
     {"type": "settings", "emoji": "⚙️", "label": "Settings"},
     {"type": "clock", "emoji": "⏰", "label": "Clock"},
-    {"type": "html-studio", "emoji": "🌐", "label": "HTML Studio"}
+    {"type": "html-studio", "emoji": "🌐", "label": "HTML Studio"},
+    {"type": "cloud-storage", "emoji": "☁️", "label": "Cloud Storage"}
   ],
   "windows": {
     "system-info": {
@@ -143,6 +144,12 @@
       "content": "<iframe src=\"html-studio.html\" style=\"width:100%;height:100%;border:none;\"></iframe>",
       "width": 600,
       "height": 450
+    },
+    "cloud-storage": {
+      "title": "Cloud Storage",
+      "content": "<iframe src=\"cloud-storage.html\" style=\"width:100%;height:100%;border:none;\"></iframe>",
+      "width": 500,
+      "height": 350
     }
   },
   "settings": {

--- a/apps/app1/cloud-storage.html
+++ b/apps/app1/cloud-storage.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cloud Storage</title>
+<style>
+body{font-family:Segoe UI,Tahoma,sans-serif;background:#fff;color:#333;margin:0;padding:1rem}
+main{max-width:600px;margin:0 auto}
+header{font-size:1.4rem;margin-bottom:.5rem}
+</style>
+</head>
+<body>
+<main>
+  <header>Cloud Storage</header>
+  <p>This is a placeholder for syncing a local folder with Google Drive or Dropbox.</p>
+  <p>Select a folder and authentication options in a future release.</p>
+</main>
+</body>
+</html>

--- a/apps/app1/html-studio.html
+++ b/apps/app1/html-studio.html
@@ -2,25 +2,25 @@
 <html lang="en">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Mini HTML Studio</title>
+<title>HTML Studio</title>
 <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.41.0/min/vs/loader.js"></script>
 <style>
-:root{--desktop:#1e1e1e;--header:#007acc;--hover:#0091ff;--win-bg:#202020;--win-border:#555}
+:root{--desktop:#1e1e1e;--header:#007acc;--hover:#0091ff;--accent:#0091ff;--win-bg:#202020;--win-border:#555}
 *{box-sizing:border-box;margin:0}
 html,body{height:100%;background:var(--desktop);font-family:Segoe UI,Tahoma,sans-serif;color:#ddd;overflow:hidden}
-.win{position:absolute;display:flex;flex-direction:column;background:var(--win-bg);border:2px solid var(--win-border);box-shadow:0 0 10px #000;top:15%;left:20%;width:60%;height:70%}
+.win{position:absolute;display:flex;flex-direction:column;background:var(--win-bg);border:2px solid var(--win-border);border-radius:6px;box-shadow:0 0 10px #000;top:15%;left:20%;width:60%;height:70%}
 .win.max{top:0;left:0;width:100%;height:100%}
-.title{height:30px;background:#151515;color:#fff;display:flex;align-items:center;padding-left:.6rem;cursor:grab}
-.title span{flex:1;font-size:.9rem}.title button{width:30px;border:none;background:#151515;color:#ccc}
-.title button:hover{background:#444}
-.toolbar{display:flex;align-items:center;gap:.5rem;padding:.25rem .7rem;background:#2a2a2a;font-size:.8rem}
+.title{height:30px;background:var(--header);color:#fff;display:flex;align-items:center;padding-left:.6rem;cursor:grab}
+.title span{flex:1;font-size:.9rem}.title button{width:30px;border:none;background:var(--header);color:#fff}
+.title button:hover{background:var(--accent)}
+.toolbar{display:flex;align-items:center;gap:.5rem;padding:.25rem .7rem;background:#222;font-size:.8rem}
 .btn,select{border:none;border-radius:3px;padding:.34rem .75rem;font-size:.78rem;background:#045a9e;color:#fff}
 .btn:hover,select:hover{background:var(--hover)}
 .viewBtn{font-size:1rem;padding:.2rem .6rem;background:#0a5d9f}.viewBtn.active{background:var(--header)}
 #wys{display:none;gap:.3rem;padding:.25rem .6rem;background:#e7e7e7;border-bottom:1px solid #ccc}
 #wys button{border:none;background:none;cursor:pointer;padding:.2rem .55rem;font-size:.85rem}
 #wys button:hover{background:#d0d0d0}
-#workspace{flex:1;display:grid;grid-template-columns:1fr 1fr}
+#workspace{flex:1;display:grid;grid-template-columns:1.2fr 1fr}
 #editor,#ta{width:100%;height:100%}
 #preview{width:100%;height:100%;border:none;background:#fff}
 @media(max-width:800px){#workspace{grid-template-columns:1fr;grid-template-rows:55% 45%}}
@@ -31,7 +31,7 @@ html,body{height:100%;background:var(--desktop);font-family:Segoe UI,Tahoma,sans
 </head>
 <body>
 <div class="win" id="window">
-  <div class="title" id="title"><span>Mini HTML Studio</span><button id="maxBtn">🗖</button><button id="closeBtn">✕</button></div>
+  <div class="title" id="title"><span>HTML Studio</span><button id="maxBtn">🗖</button><button id="closeBtn">✕</button></div>
   <div class="toolbar">
     <button id="codeBtn"  class="viewBtn">🖉</button>
     <button id="splitBtn" class="viewBtn active">⇆</button>


### PR DESCRIPTION
## Summary
- redesign HTML Studio window style
- add new app placeholder `cloud-storage.html`
- register Cloud Storage icon and window in WebGUI

## Testing
- `node -e "const fs=require('fs');JSON.parse(fs.readFileSync('apps/app1/app-data/app1.json'));console.log('json ok');" && echo done`


------
https://chatgpt.com/codex/tasks/task_e_68869b99f0f8832ab89e207d9ef85601