### PR TITLE
Update to v0.0.17alfa and simplify HTML Studio

### DIFF
--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -41,10 +41,10 @@
   ],
   "status": "Icons are now clickable! Click any icon to open an application.",
   "welcome": {
-    "title": "WebGUI 0.0.17",
+    "title": "WebGUI 0.0.17alfa",
     "lines": [
       "Welcome to WebGUI - Web browser based windows GUI",
-      "Version 0.0.17",
+      "Version 0.0.17alfa",
       "(c) 2025 CyborgsDream"
     ],
     "button": "OK"
@@ -69,7 +69,7 @@
   "windows": {
     "system-info": {
       "title": "System Information",
-      "content": "<h2>WebGUI Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>WebGUI 0.0.17</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Power Without the Price</div></div>",
+      "content": "<h2>WebGUI Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>WebGUI 0.0.17alfa</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Power Without the Price</div></div>",
       "width": 320,
       "height": 300
     },
@@ -81,7 +81,7 @@
     },
     "text-editor": {
       "title": "Text Editor",
-      "content": "<textarea style=\"width: 100%; height: 100%; background: #fff; border: 1px solid #aaa; padding: 5px; font-family: monospace; font-size: 18px;\">Welcome to WebGUI 0.0.17!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea>",
+      "content": "<textarea style=\"width: 100%; height: 100%; background: #fff; border: 1px solid #aaa; padding: 5px; font-family: monospace; font-size: 18px;\">Welcome to WebGUI 0.0.17alfa!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea>",
       "width": 500,
       "height": 350
     },

--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>WebGUI 0.0.17</title>
+    <title>WebGUI 0.0.17alfa</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=VT323&display=swap">
     <style>
         * {

--- a/apps/app1/html-studio.html
+++ b/apps/app1/html-studio.html
@@ -7,12 +7,7 @@
 <style>
 :root{--desktop:#1e1e1e;--header:#007acc;--hover:#0091ff;--accent:#0091ff;--win-bg:#202020;--win-border:#555}
 *{box-sizing:border-box;margin:0}
-html,body{height:100%;background:var(--desktop);font-family:Segoe UI,Tahoma,sans-serif;color:#ddd;overflow:hidden}
-.win{position:absolute;display:flex;flex-direction:column;background:var(--win-bg);border:2px solid var(--win-border);border-radius:6px;box-shadow:0 0 10px #000;top:15%;left:20%;width:60%;height:70%}
-.win.max{top:0;left:0;width:100%;height:100%}
-.title{height:30px;background:var(--header);color:#fff;display:flex;align-items:center;padding-left:.6rem;cursor:grab}
-.title span{flex:1;font-size:.9rem}.title button{width:30px;border:none;background:var(--header);color:#fff}
-.title button:hover{background:var(--accent)}
+html,body{height:100%;background:var(--win-bg);font-family:Segoe UI,Tahoma,sans-serif;color:#ddd;overflow:hidden;display:flex;flex-direction:column}
 .toolbar{display:flex;align-items:center;gap:.5rem;padding:.25rem .7rem;background:#222;font-size:.8rem}
 .btn,select{border:none;border-radius:3px;padding:.34rem .75rem;font-size:.78rem;background:#045a9e;color:#fff}
 .btn:hover,select:hover{background:var(--hover)}
@@ -30,8 +25,7 @@ html,body{height:100%;background:var(--desktop);font-family:Segoe UI,Tahoma,sans
 </style>
 </head>
 <body>
-<div class="win" id="window">
-  <div class="title" id="title"><span>HTML Studio</span><button id="maxBtn">🗖</button><button id="closeBtn">✕</button></div>
+
   <div class="toolbar">
     <button id="codeBtn"  class="viewBtn">🖉</button>
     <button id="splitBtn" class="viewBtn active">⇆</button>
@@ -48,21 +42,12 @@ html,body{height:100%;background:var(--desktop);font-family:Segoe UI,Tahoma,sans
   </div>
   <div id="workspace"><div id="editor"></div><iframe id="preview"></iframe></div>
   <pre id="console"></pre><div class="status"><span id="verInfo">ver:0</span><span id="sizeInfo">size:0</span></div>
-</div>
 <script>
 const $=id=>document.getElementById(id);
 const log=(m,t='info')=>{$('console').appendChild(Object.assign(document.createElement('div'),{className:'log-line '+t,textContent:m}));$('console').scrollTop=$('console').scrollHeight;};
 window.onerror=m=>log('Error: '+m,'err');
 const pretty=html=>html.replace(/></g,">\n<");
 let editor;
-document.getElementById('maxBtn').onclick=()=>document.getElementById('window').classList.toggle('max');
-document.getElementById('closeBtn').onclick=()=>{
-  const frame=window.frameElement;
-  if(frame){
-    const win=frame.closest('.window');
-    if(win&&parent.WinAPI&&parent.WinAPI.closeWindow) parent.WinAPI.closeWindow(win.id);
-  }
-};
 const template=pretty(`<!doctype html><html><head><meta charset="utf-8"><title>Demo</title><style>body{font-family:sans-serif;padding:2rem}</style></head><body><h1>Hello!</h1><p>Edit code or <em>WYSIWYG</em>.</p></body></html>`);
 const LS='studio-snaps',load=()=>JSON.parse(localStorage.getItem(LS)||'[]'),save=a=>localStorage.setItem(LS,JSON.stringify(a));
 function setupPreview(){

--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/* Version: 0.0.17 */
+/* Version: 0.0.17alfa */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!--
-Version: 0.0.17
+Version: 0.0.17alfa
 Codename: Celestia
 Change Log:
  - Initial responsive boilerplate
@@ -12,7 +12,7 @@ Change Log:
 - Switched object labels to <h3> elements
  - Made info text white for visibility
 - Removed console log background and limited visibility to 3 seconds
- - Bumped version to 0.0.17
+ - Bumped version to 0.0.17alfa
  - Reduced DEMOS text wave range and limited movement to Z axis
 - Raised demo objects and enabled inter-object shadows
 - Set console log text to 50% opacity
@@ -32,7 +32,7 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
-      <div id="version-number">v0.0.17</div>
+      <div id="version-number">v0.0.17alfa</div>
       <div id="console-log"></div>
       <div id="app-info">
         <span id="close-info" class="close-icon" aria-label="Close">&times;</span>

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,4 @@
-// Version: 0.0.17
+// Version: 0.0.17alfa
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';


### PR DESCRIPTION
## Summary
- bump version strings to **0.0.17alfa**
- remove extra window wrapper from HTML Studio
- keep HTML Studio editor and preview panes side by side

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887369aea90832a8112a8ebd545efb2