### PR TITLE
Update HTML Studio and bump version

### DIFF
--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -41,10 +41,10 @@
   ],
   "status": "Icons are now clickable! Click any icon to open an application.",
   "welcome": {
-    "title": "WebGUI 0.0.17",
+    "title": "WebGUI 0.0.17alfa",
     "lines": [
       "Welcome to WebGUI - Web browser based windows GUI",
-      "Version 0.0.17",
+      "Version 0.0.17alfa",
       "(c) 2025 CyborgsDream"
     ],
     "button": "OK"
@@ -69,7 +69,7 @@
   "windows": {
     "system-info": {
       "title": "System Information",
-      "content": "<h2>WebGUI Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>WebGUI 0.0.17</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Power Without the Price</div></div>",
+      "content": "<h2>WebGUI Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>WebGUI 0.0.17alfa</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Power Without the Price</div></div>",
       "width": 320,
       "height": 300
     },
@@ -81,7 +81,7 @@
     },
     "text-editor": {
       "title": "Text Editor",
-      "content": "<textarea style=\"width: 100%; height: 100%; background: #fff; border: 1px solid #aaa; padding: 5px; font-family: monospace; font-size: 18px;\">Welcome to WebGUI 0.0.17!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea>",
+      "content": "<textarea style=\"width: 100%; height: 100%; background: #fff; border: 1px solid #aaa; padding: 5px; font-family: monospace; font-size: 18px;\">Welcome to WebGUI 0.0.17alfa!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea>",
       "width": 500,
       "height": 350
     },
@@ -141,7 +141,7 @@
     },
     "html-studio": {
       "title": "HTML Studio",
-      "content": "<iframe src=\"html-studio.html\" style=\"width:100%;height:100%;border:none;\"></iframe>",
+      "content": "<div id=\"htmlstudio-container\" style=\"width:100%;height:100%;overflow:hidden;\"></div>",
       "width": 600,
       "height": 450
     },

--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>WebGUI 0.0.17</title>
+    <title>WebGUI 0.0.17alfa</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=VT323&display=swap">
     <style>
         * {

--- a/apps/app1/app-js/htmlstudio.js
+++ b/apps/app1/app-js/htmlstudio.js
@@ -1,1 +1,24 @@
 WinAPI.createWindow('html-studio');
+
+setTimeout(() => {
+  const win = document.querySelector('.window:last-of-type');
+  if (!win) return;
+  const container = win.querySelector('#htmlstudio-container') || win.querySelector('.window-content');
+  fetch('html-studio.html')
+    .then(r => r.text())
+    .then(t => {
+      const doc = new DOMParser().parseFromString(t, 'text/html');
+      doc.head.querySelectorAll('style,link[rel="stylesheet"]').forEach(el => {
+        container.appendChild(el.cloneNode(true));
+      });
+      doc.body.childNodes.forEach(node => {
+        container.appendChild(node.cloneNode(true));
+      });
+      doc.querySelectorAll('script').forEach(scr => {
+        const s = document.createElement('script');
+        if (scr.src) s.src = scr.src;
+        else s.textContent = scr.textContent;
+        container.appendChild(s);
+      });
+    });
+}, 0);

--- a/apps/app1/html-studio.html
+++ b/apps/app1/html-studio.html
@@ -19,7 +19,6 @@ body{display:flex;flex-direction:column;background:var(--win-bg)}
 #workspace{flex:1;display:grid;grid-template-columns:1.2fr 1fr}
 #editor,#ta{width:100%;height:100%}
 #preview{width:100%;height:100%;border:none;background:#fff}
-@media(max-width:800px){#workspace{grid-template-columns:1fr;grid-template-rows:55% 45%}}
 #console{background:#000;font-family:monospace;font-size:.72rem;max-height:70px;overflow-y:auto;white-space:pre-wrap;padding:.25rem .5rem}
 .log-line{padding:1px 0}.err{color:#f66}.warn{color:#f2b648}.info{color:#8ad}
 .status{height:24px;background:#111;font-size:.73rem;color:#888;display:flex;justify-content:space-between;align-items:center;padding:0 .6rem;font-family:monospace}

--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/* Version: 0.0.17 */
+/* Version: 0.0.17alfa */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!--
-Version: 0.0.17
+Version: 0.0.17alfa
 Codename: Celestia
 Change Log:
  - Initial responsive boilerplate
@@ -12,7 +12,7 @@ Change Log:
 - Switched object labels to <h3> elements
  - Made info text white for visibility
 - Removed console log background and limited visibility to 3 seconds
- - Bumped version to 0.0.17
+ - Bumped version to 0.0.17alfa
  - Reduced DEMOS text wave range and limited movement to Z axis
 - Raised demo objects and enabled inter-object shadows
 - Set console log text to 50% opacity
@@ -32,7 +32,7 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
-      <div id="version-number">v0.0.17</div>
+      <div id="version-number">v0.0.17alfa</div>
       <div id="console-log"></div>
       <div id="app-info">
         <span id="close-info" class="close-icon" aria-label="Close">&times;</span>

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,4 @@
-// Version: 0.0.17
+// Version: 0.0.17alfa
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';


### PR DESCRIPTION
## Summary
- bump all version strings to 0.0.17alfa
- remove responsive media rule so the code and preview panes stay side by side
- load HTML Studio directly in the window instead of using an inner iframe

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688739723340832a9d45e61307805b84