### PR TITLE
Fix HTML Studio errors and add console log window

### DIFF
--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -139,9 +139,15 @@
       "width": 200,
       "height": 150
     },
+    "console-log": {
+      "title": "Console Logs",
+      "content": "<div class=\"console-log-window\" style=\"width:100%;height:100%;background:#000;color:#0f0;font-family:monospace;overflow:auto;font-size:16px;padding:4px;\"></div>",
+      "width": 400,
+      "height": 250
+    },
     "html-studio": {
       "title": "HTML Studio",
-      "content": "<div id=\"htmlstudio-container\" style=\"width:100%;height:100%;overflow:hidden;\"></div>",
+      "content": "<iframe src=\"html-studio.html\" style=\"width:100%;height:100%;border:none;\"></iframe>",
       "width": 600,
       "height": 450
     },

--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -716,8 +716,9 @@
             makeDraggable(id);
             state.windows.push(id);
             updateTaskBar();
-            
+
             // App specific initialization can be handled by each module
+            return id;
         }
         
         function getWindowConfig(type) {
@@ -844,6 +845,11 @@
             initClock(appData.settings && appData.settings.clockFormat);
             initMenus();
             updateTaskBar();
+            const logId = openWindow('console-log');
+            import('../../shared/consolelogs.js').then(({ initConsoleLogs }) => {
+                const el = document.getElementById(logId)?.querySelector('.window-content');
+                if (el) initConsoleLogs({ container: el, removeAfter: null });
+            });
         }
 
         function updateViewportHeight() {

--- a/apps/app1/app-js/cloud-storage.js
+++ b/apps/app1/app-js/cloud-storage.js
@@ -1,0 +1,1 @@
+WinAPI.createWindow('cloud-storage');

--- a/apps/app1/app-js/htmlstudio.js
+++ b/apps/app1/app-js/htmlstudio.js
@@ -1,24 +1,2 @@
+// Simple loader for HTML Studio using an iframe defined in app-data
 WinAPI.createWindow('html-studio');
-
-setTimeout(() => {
-  const win = document.querySelector('.window:last-of-type');
-  if (!win) return;
-  const container = win.querySelector('#htmlstudio-container') || win.querySelector('.window-content');
-  fetch('html-studio.html')
-    .then(r => r.text())
-    .then(t => {
-      const doc = new DOMParser().parseFromString(t, 'text/html');
-      doc.head.querySelectorAll('style,link[rel="stylesheet"]').forEach(el => {
-        container.appendChild(el.cloneNode(true));
-      });
-      doc.body.childNodes.forEach(node => {
-        container.appendChild(node.cloneNode(true));
-      });
-      doc.querySelectorAll('script').forEach(scr => {
-        const s = document.createElement('script');
-        if (scr.src) s.src = scr.src;
-        else s.textContent = scr.textContent;
-        container.appendChild(s);
-      });
-    });
-}, 0);

--- a/js/script.js
+++ b/js/script.js
@@ -2,28 +2,11 @@
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';
+import { initConsoleLogs } from '../shared/consolelogs.js';
 const { apps } = await fetch('data/index.json').then(r => r.json());
 const consoleLogEl = document.getElementById('console-log');
 if (consoleLogEl) {
-  const methods = ['log', 'info', 'warn', 'error'];
-  const original = {};
-  methods.forEach(m => {
-    original[m] = console[m].bind(console);
-    console[m] = (...args) => {
-      original[m](...args);
-      const msg = args
-        .map(a => (typeof a === 'object' ? JSON.stringify(a) : String(a)))
-        .join(' ');
-      const line = document.createElement('div');
-      line.className = `console-line ${m}`;
-      line.style.background = 'none';
-      line.style.opacity = '0.5';
-      line.textContent = `[${m}] ${msg}`;
-      consoleLogEl.appendChild(line);
-      consoleLogEl.scrollTop = consoleLogEl.scrollHeight;
-      setTimeout(() => line.remove(), 3000);
-    };
-  });
+  initConsoleLogs({ container: consoleLogEl, removeAfter: 3000 });
 }
 console.log('Responsive boilerplate loaded');
 

--- a/shared/consolelogs.js
+++ b/shared/consolelogs.js
@@ -1,0 +1,35 @@
+export function initConsoleLogs({container, removeAfter=3000}={}) {
+  if (!container) {
+    container = document.createElement('div');
+    container.id = 'console-log';
+    Object.assign(container.style, {
+      position: 'absolute', bottom: '0', left: '0', width: '100%',
+      maxHeight: '100px', overflowY: 'auto', color: '#0f0',
+      background: 'none', fontFamily: 'monospace', fontSize: '0.65rem',
+      padding: '2px 4px', pointerEvents: 'none', zIndex: 30
+    });
+    document.body.appendChild(container);
+  }
+  const methods = ['log', 'info', 'warn', 'error'];
+  const original = {};
+  methods.forEach(m => {
+    original[m] = console[m].bind(console);
+    console[m] = (...args) => {
+      original[m](...args);
+      const msg = args.map(a => {
+        try { return typeof a === 'object' ? JSON.stringify(a) : String(a); }
+        catch { return String(a); }
+      }).join(' ');
+      const line = document.createElement('div');
+      line.className = `console-line ${m}`;
+      line.textContent = `[${m}] ${msg}`;
+      container.appendChild(line);
+      container.scrollTop = container.scrollHeight;
+      if (removeAfter) setTimeout(() => line.remove(), removeAfter);
+    };
+  });
+  return {
+    container,
+    restore() { methods.forEach(m => console[m] = original[m]); }
+  };
+}


### PR DESCRIPTION
## Summary
- create reusable `initConsoleLogs` library
- use library from the main demo scene
- simplify HTML Studio loader and use iframe
- add missing Cloud Storage loader script
- open Console Logs window on WebGUI startup

## Testing
- `node -e "console.log('test run')"`

------
https://chatgpt.com/codex/tasks/task_e_68873eb95024832aad5271b4641ee885