### PR TITLE
Add API-based mini apps to WinGUI

### DIFF
--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -26,7 +26,9 @@
         {"label": "Calculator", "type": "calculator"},
         {"label": "Calendar", "type": "calendar"},
         {"label": "Puzzle Game", "type": "puzzle-game"},
-        {"label": "Disk Doctor"}
+        {"label": "Disk Doctor"},
+        {"label": "Jokes", "type": "jokes"},
+        {"label": "Activity", "type": "activity"}
       ]
     },
     {
@@ -64,7 +66,9 @@
     {"type": "settings", "emoji": "⚙️", "label": "Settings"},
     {"type": "clock", "emoji": "⏰", "label": "Clock"},
     {"type": "html-studio", "emoji": "🌐", "label": "HTML Studio"},
-    {"type": "cloud-storage", "emoji": "☁️", "label": "Cloud Storage"}
+    {"type": "cloud-storage", "emoji": "☁️", "label": "Cloud Storage"},
+    {"type": "jokes", "emoji": "😂", "label": "Jokes"},
+    {"type": "activity", "emoji": "🎲", "label": "Activity"}
   ],
   "windows": {
     "system-info": {
@@ -156,6 +160,18 @@
       "content": "<iframe src=\"cloud-storage.html\" style=\"width:100%;height:100%;border:none;\"></iframe>",
       "width": 500,
       "height": 350
+    },
+    "jokes": {
+      "title": "Random Joke",
+      "content": "<div id=\"joke-area\" style=\"padding:10px;font-size:18px\">Loading...</div><button onclick=\"fetchJoke()\" style=\"margin-top:10px\">New Joke</button>",
+      "width": 400,
+      "height": 200
+    },
+    "activity": {
+      "title": "Random Activity",
+      "content": "<div id=\"activity-area\" style=\"padding:10px;font-size:18px\">Click the button for an activity</div><button onclick=\"fetchActivity()\" style=\"margin-top:10px\">Get Activity</button>",
+      "width": 400,
+      "height": 200
     }
   },
   "settings": {

--- a/apps/app1/app-js/activity.js
+++ b/apps/app1/app-js/activity.js
@@ -1,0 +1,16 @@
+WinAPI.createWindow('activity');
+
+window.fetchActivity = async function() {
+    const el = document.getElementById('activity-area');
+    if (!el) return;
+    el.textContent = 'Loading...';
+    try {
+        const res = await fetch('https://www.boredapi.com/api/activity/');
+        const data = await res.json();
+        el.textContent = data.activity;
+    } catch {
+        el.textContent = 'Error fetching activity.';
+    }
+};
+
+fetchActivity();

--- a/apps/app1/app-js/jokes.js
+++ b/apps/app1/app-js/jokes.js
@@ -1,0 +1,16 @@
+WinAPI.createWindow('jokes');
+
+window.fetchJoke = async function() {
+    const el = document.getElementById('joke-area');
+    if (!el) return;
+    el.textContent = 'Loading...';
+    try {
+        const res = await fetch('https://v2.jokeapi.dev/joke/Programming?type=single');
+        const data = await res.json();
+        el.textContent = data.joke;
+    } catch {
+        el.textContent = 'Error fetching joke.';
+    }
+};
+
+fetchJoke();


### PR DESCRIPTION
## Summary
- add `jokes.js` and `activity.js` mini apps that use JokeAPI and BoredAPI
- register the new apps in app1 menus, icons and windows

## Testing
- `node --check apps/app1/app-js/jokes.js`
- `node --check apps/app1/app-js/activity.js`
- `node -e "const fs=require('fs');JSON.parse(fs.readFileSync('apps/app1/app-data/app1.json','utf8'));console.log('JSON OK');"`

------
https://chatgpt.com/codex/tasks/task_e_68877be5d908832a81caccd3a461f496