### PR TITLE
Improve Clock app and add WinGUI logs

### DIFF
--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -44,10 +44,10 @@
   ],
   "status": "Ready.",
   "welcome": {
-    "title": "WebGUI 0.0.17h",
+    "title": "WebGUI 0.0.17i",
     "lines": [
       "Welcome to WebGUI - Web browser based windows GUI",
-      "Version 0.0.17h",
+      "Version 0.0.17i",
       "(c) 2025 CyborgsDream"
     ],
     "button": "OK"
@@ -75,7 +75,7 @@
   "windows": {
     "system-info": {
       "title": "System Information",
-      "content": "<h2>WebGUI Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>WebGUI 0.0.17h</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Power Without the Price</div></div>",
+      "content": "<h2>WebGUI Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>WebGUI 0.0.17i</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Power Without the Price</div></div>",
       "width": 320,
       "height": 300
     },
@@ -87,7 +87,7 @@
     },
     "text-editor": {
       "title": "Text Editor",
-      "content": "<textarea style=\"width: 100%; height: 100%; background: #fff; border: 1px solid #aaa; padding: 5px; font-family: monospace; font-size: 18px;\">Welcome to WebGUI 0.0.17h!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea>",
+      "content": "<textarea style=\"width: 100%; height: 100%; background: #fff; border: 1px solid #aaa; padding: 5px; font-family: monospace; font-size: 18px;\">Welcome to WebGUI 0.0.17i!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea>",
       "width": 500,
       "height": 350
     },
@@ -141,9 +141,9 @@
     },
     "clock": {
       "title": "Clock",
-      "content": "<div id=\"live-clock\" style=\"font-size:32px;text-align:center;\">{TIME}</div>",
+      "content": "<div style=\"text-align:center\"><div id=\"live-clock\" style=\"font-size:32px;margin-bottom:10px\">{TIME}</div><button id=\"toggle-clock-format\">24h</button></div>",
       "width": 200,
-      "height": 150
+      "height": 170
     },
     "console-log": {
       "title": "Console Logs",

--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>WebGUI 0.0.17h</title>
+    <title>WebGUI 0.0.17i</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=VT323&display=swap">
     <style>
         * {
@@ -240,6 +240,22 @@
             font-size: 18px;
             line-height: 1.4;
             background: #c0c0c0;
+            position: relative;
+        }
+
+        .loading-overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: rgba(255, 255, 255, 0.7);
+            color: #000;
+            font-size: 18px;
+            z-index: 5;
         }
         
         .terminal {
@@ -642,6 +658,12 @@
                 link.href = `app-js/${safe}.js`;
                 document.head.appendChild(link);
             });
+            ['html-studio.html', 'cloud-storage.html'].forEach(p => {
+                const l = document.createElement('link');
+                l.rel = 'prefetch';
+                l.href = p;
+                document.head.appendChild(l);
+            });
         }
 
         function buildWelcome(welcome) {
@@ -712,6 +734,7 @@
         
         // Window management - FIXED ICON FUNCTIONALITY
         function openWindow(type) {
+            console.log('Opening window:', type);
             const windowConfig = getWindowConfig(type);
             if (!windowConfig) return;
 
@@ -742,9 +765,18 @@
             `;
             
             desktop.insertAdjacentHTML('beforeend', windowHtml);
+            const winEl = document.getElementById(id);
             makeDraggable(id);
             state.windows.push(id);
             updateTaskBar();
+            const iframe = winEl.querySelector('iframe');
+            if (iframe) {
+                const loader = document.createElement('div');
+                loader.className = 'loading-overlay';
+                loader.textContent = 'Loading...';
+                winEl.querySelector('.window-content').appendChild(loader);
+                iframe.addEventListener('load', () => loader.remove());
+            }
             if (type === 'console-log') {
                 import('../../shared/consolelogs.js').then(({ initConsoleLogs }) => {
                     const el = document
@@ -776,17 +808,19 @@
             return { title: cfg.title, content, width: cfg.width, height: cfg.height };
         }
         
-        function closeWindow(id) {
-            const window = document.getElementById(id);
+       function closeWindow(id) {
+           const window = document.getElementById(id);
             if (window) window.remove();
+            console.log('Window closed:', id);
             state.windows = state.windows.filter(winId => winId !== id);
             updateTaskBar();
         }
 
-        function minimizeWindow(id) {
-            const window = document.getElementById(id);
-            if (window) {
-                window.style.display = 'none';
+       function minimizeWindow(id) {
+           const window = document.getElementById(id);
+           if (window) {
+               window.style.display = 'none';
+                console.log('Window minimized:', id);
                 updateTaskBar();
             }
         }
@@ -810,15 +844,16 @@
             });
         }
         
-        function maximizeWindow(id) {
-            const window = document.getElementById(id);
-            if (window) {
-                if (window.dataset.maximized === 'true') {
+       function maximizeWindow(id) {
+           const window = document.getElementById(id);
+           if (window) {
+               if (window.dataset.maximized === 'true') {
                     window.style.width = window.dataset.initWidth + 'px';
                     window.style.height = window.dataset.initHeight + 'px';
                     window.style.top = window.dataset.initTop + 'px';
                     window.style.left = window.dataset.initLeft + 'px';
                     window.dataset.maximized = 'false';
+                    console.log('Window restored:', id);
                 } else {
                     window.dataset.initWidth = window.offsetWidth;
                     window.dataset.initHeight = window.offsetHeight;
@@ -829,6 +864,7 @@
                     window.style.top = '30px';
                     window.style.left = '10px';
                     window.dataset.maximized = 'true';
+                    console.log('Window maximized:', id);
                 }
                 window.style.zIndex = ++state.zIndex;
                 updateTaskBar();

--- a/apps/app1/app-js/clock.js
+++ b/apps/app1/app-js/clock.js
@@ -1,13 +1,27 @@
-WinAPI.createWindow('clock');
+const id = WinAPI.createWindow('clock');
 
 function getClockLocale() {
     const data = window.appData || {};
     return (data.settings && data.settings.clockFormat) || navigator.language || 'en-US';
 }
 
-setInterval(() => {
-    const el = document.getElementById('live-clock');
-    if (el) {
-        el.textContent = new Date().toLocaleTimeString(getClockLocale());
-    }
-}, 1000);
+const container = document.getElementById(id);
+const el = container?.querySelector('#live-clock');
+const btn = container?.querySelector('#toggle-clock-format');
+let use24 = false;
+const locale = getClockLocale();
+
+function update() {
+    if (el) el.textContent = new Date().toLocaleTimeString(locale, { hour12: !use24 });
+}
+
+setInterval(update, 1000);
+update();
+if (btn) {
+    btn.onclick = () => {
+        use24 = !use24;
+        btn.textContent = use24 ? '12h' : '24h';
+        console.log('Clock format toggled:', use24 ? '24h' : '12h');
+        update();
+    };
+}

--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/* Version: 0.0.17h */
+/* Version: 0.0.17i */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!--
-Version: 0.0.17h
+Version: 0.0.17i
 Codename: Celestia
 Change Log:
  - Initial responsive boilerplate
@@ -12,7 +12,7 @@ Change Log:
 - Switched object labels to <h3> elements
  - Made info text white for visibility
 - Removed console log background and limited visibility to 3 seconds
- - Bumped version to 0.0.17h
+ - Bumped version to 0.0.17i
  - Reduced DEMOS text wave range and limited movement to Z axis
 - Raised demo objects and enabled inter-object shadows
 - Set console log text to 50% opacity
@@ -32,7 +32,7 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
-      <div id="version-number">v0.0.17h</div>
+      <div id="version-number">v0.0.17i</div>
       <div id="console-log"></div>
       <div id="app-info">
         <span id="close-info" class="close-icon" aria-label="Close">&times;</span>

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,4 @@
-// Version: 0.0.17h
+// Version: 0.0.17i
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';


### PR DESCRIPTION
## Summary
- bump version to **0.0.17i** across the project
- prefetch heavy HTML files
- add loading overlay when opening iframe windows
- allow toggling 12h/24h format in the Clock app
- log window actions to the console

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6887891c4a80832a87b73df07ebc1707