### PR TITLE
Add taskbar menu and window sizing

### DIFF
--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -44,10 +44,10 @@
   ],
   "status": "Ready.",
   "welcome": {
-    "title": "WebGUI 0.0.17i",
+    "title": "WebGUI 0.0.17j",
     "lines": [
       "Welcome to WebGUI - Web browser based windows GUI",
-      "Version 0.0.17i",
+      "Version 0.0.17j",
       "(c) 2025 CyborgsDream"
     ],
     "button": "OK"
@@ -75,7 +75,7 @@
   "windows": {
     "system-info": {
       "title": "System Information",
-      "content": "<h2>WebGUI Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>WebGUI 0.0.17i</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Power Without the Price</div></div>",
+      "content": "<h2>WebGUI Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>WebGUI 0.0.17j</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Power Without the Price</div></div>",
       "width": 320,
       "height": 300
     },
@@ -87,7 +87,7 @@
     },
     "text-editor": {
       "title": "Text Editor",
-      "content": "<textarea style=\"width: 100%; height: 100%; background: #fff; border: 1px solid #aaa; padding: 5px; font-family: monospace; font-size: 18px;\">Welcome to WebGUI 0.0.17i!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea>",
+      "content": "<textarea style=\"width: 100%; height: 100%; background: #fff; border: 1px solid #aaa; padding: 5px; font-family: monospace; font-size: 18px;\">Welcome to WebGUI 0.0.17j!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea>",
       "width": 500,
       "height": 350
     },
@@ -174,6 +174,12 @@
       "content": "<div id=\"activity-area\" style=\"padding:10px;font-size:18px\">Click the button for an activity</div><button onclick=\"fetchActivity()\" style=\"margin-top:10px\">Get Activity</button>",
       "width": 400,
       "height": 200
+    },
+    "mini-app": {
+      "title": "Mini App",
+      "content": "<p>Mini app pinned!</p>",
+      "width": 160,
+      "height": 120
     }
   },
   "settings": {

--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>WebGUI 0.0.17i</title>
+    <title>WebGUI 0.0.17j</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=VT323&display=swap">
     <style>
         * {
@@ -355,7 +355,28 @@
             background: linear-gradient(to bottom, #0066cc, #004499);
             color: #fff;
         }
-        
+
+        .taskbar-menu {
+            position: absolute;
+            background: #ccc;
+            border: 1px solid #555;
+            color: #000;
+            bottom: 26px;
+            z-index: 15;
+            display: none;
+        }
+
+        .taskbar-menu div {
+            padding: 5px 15px;
+            white-space: nowrap;
+            cursor: pointer;
+        }
+
+        .taskbar-menu div:hover {
+            background: #0066cc;
+            color: #fff;
+        }
+
         .dialog {
             position: absolute;
             top: 50%;
@@ -569,6 +590,7 @@
 
         <!-- Task bar -->
         <div class="task-bar" id="task-bar"></div>
+        <div class="taskbar-menu" id="taskbar-menu" style="display:none;"></div>
         
         <!-- Welcome dialog -->
         <div class="dialog" id="welcome-dialog" style="display:none;">
@@ -738,6 +760,11 @@
             const windowConfig = getWindowConfig(type);
             if (!windowConfig) return;
 
+            let winWidth = windowConfig.width;
+            let winHeight = windowConfig.height;
+            if (window.innerWidth < winWidth) winWidth = window.innerWidth - 20;
+            if (window.innerHeight < winHeight) winHeight = window.innerHeight - 40;
+
             const id = `window-${++state.windowCount}`;
             state.zIndex++;
             const top = 50 + state.windowCount * 20;
@@ -745,11 +772,11 @@
 
             const windowHtml = `
                 <div class="window" id="${id}"
-                     data-init-width="${windowConfig.width}"
-                     data-init-height="${windowConfig.height}"
+                     data-init-width="${winWidth}"
+                     data-init-height="${winHeight}"
                      data-init-top="${top}"
                      data-init-left="${left}"
-                     style="top: ${top}px; left: ${left}px; width: ${windowConfig.width}px; height: ${windowConfig.height}px; z-index: ${state.zIndex}">
+                     style="top: ${top}px; left: ${left}px; width: ${winWidth}px; height: ${winHeight}px; z-index: ${state.zIndex}">
                     <div class="window-header">
                         <div class="window-title">${windowConfig.title}</div>
                         <div class="window-controls">
@@ -843,6 +870,29 @@
                 bar.appendChild(btn);
             });
         }
+
+        function initTaskBarMenu() {
+            const bar = document.getElementById('task-bar');
+            const menu = document.getElementById('taskbar-menu');
+            menu.innerHTML = '';
+            const pin = document.createElement('div');
+            pin.textContent = 'Pin Mini App';
+            pin.onclick = () => {
+                openWindow('mini-app');
+                menu.style.display = 'none';
+            };
+            menu.appendChild(pin);
+
+            bar.addEventListener('contextmenu', e => {
+                e.preventDefault();
+                menu.style.left = e.clientX + 'px';
+                menu.style.display = 'block';
+            });
+
+            document.addEventListener('click', () => {
+                menu.style.display = 'none';
+            });
+        }
         
        function maximizeWindow(id) {
            const window = document.getElementById(id);
@@ -925,6 +975,7 @@
             initClock(appData.settings && appData.settings.clockFormat);
             initMenus();
             updateTaskBar();
+            initTaskBarMenu();
             const logId = openWindow('console-log');
             import('../../shared/consolelogs.js').then(({ initConsoleLogs }) => {
                 const el = document

--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/* Version: 0.0.17i */
+/* Version: 0.0.17j */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!--
-Version: 0.0.17i
+Version: 0.0.17j
 Codename: Celestia
 Change Log:
  - Initial responsive boilerplate
@@ -12,7 +12,7 @@ Change Log:
 - Switched object labels to <h3> elements
  - Made info text white for visibility
 - Removed console log background and limited visibility to 3 seconds
- - Bumped version to 0.0.17i
+ - Bumped version to 0.0.17j
  - Reduced DEMOS text wave range and limited movement to Z axis
 - Raised demo objects and enabled inter-object shadows
 - Set console log text to 50% opacity
@@ -32,7 +32,7 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
-      <div id="version-number">v0.0.17i</div>
+      <div id="version-number">v0.0.17j</div>
       <div id="console-log"></div>
       <div id="app-info">
         <span id="close-info" class="close-icon" aria-label="Close">&times;</span>

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,4 @@
-// Version: 0.0.17i
+// Version: 0.0.17j
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';


### PR DESCRIPTION
## Summary
- support right-click taskbar context menu in app1
- restrict app1 windows to screen size on mobile
- add mini-app window definition
- bump project version to 0.0.17j across docs and code

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_688791ccc7d0832ab07e178a04b841f3