### PR TITLE
feat: add log filtering and clearing

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -6,7 +6,11 @@ import { initConsoleLogs } from '../shared/consolelogs.js';
 const { apps } = await fetch('data/index.json').then(r => r.json());
 const consoleLogEl = document.getElementById('console-log');
 if (consoleLogEl) {
-  initConsoleLogs({ container: consoleLogEl, removeAfter: 3000 });
+  initConsoleLogs({
+    container: consoleLogEl,
+    removeAfter: 3000,
+    filter: ['info', 'warn', 'error']
+  });
 }
 console.log('Responsive boilerplate loaded');
 


### PR DESCRIPTION
## Summary
- add filter, clear and append helpers to in-browser console log monitor
- use new filter option in main script to hide standard logs

## Testing
- `node server.js & sleep 1; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_68987c539690832a87f3e7bcc8812c84