### PR TITLE
feat: add pdf export to text editor

### DIFF
--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -87,7 +87,7 @@
     },
     "text-editor": {
       "title": "Text Editor",
-      "content": "<textarea style=\"width: 100%; height: 100%; background: #fff; border: 1px solid #aaa; padding: 5px; font-family: monospace; font-size: 18px;\">Welcome to WebGUI 0.0.18!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea>",
+      "content": "<div class=\"text-editor\" style=\"display:flex;flex-direction:column;height:100%\"><div style=\"text-align:right;margin-bottom:5px;\"><button id=\"text-editor-export\" style=\"font-size:16px;\">Export PDF</button></div><textarea id=\"text-editor-area\" style=\"flex:1;background:#fff;border:1px solid #aaa;padding:5px;font-family:monospace;font-size:18px;\">Welcome to WebGUI 0.0.18!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea></div>",
       "width": 500,
       "height": 350
     },

--- a/apps/app1/app-js/textedit.js
+++ b/apps/app1/app-js/textedit.js
@@ -1,1 +1,25 @@
-WinAPI.createWindow('text-editor');
+const id = WinAPI.createWindow('text-editor');
+
+const win = document.getElementById(id);
+const textarea = win?.querySelector('#text-editor-area');
+const exportBtn = win?.querySelector('#text-editor-export');
+
+function loadJsPDF(callback){
+    if(window.jspdf){ callback(); return; }
+    const script=document.createElement('script');
+    script.src='https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js';
+    script.onload=callback;
+    document.head.appendChild(script);
+}
+
+if(exportBtn && textarea){
+    exportBtn.addEventListener('click',()=>{
+        loadJsPDF(()=>{
+            const { jsPDF } = window.jspdf;
+            const doc = new jsPDF();
+            const lines = doc.splitTextToSize(textarea.value,180);
+            doc.text(lines,10,10);
+            doc.save('document.pdf');
+        });
+    });
+}


### PR DESCRIPTION
## Summary
- extend text editor window with export to PDF button
- implement dynamic jsPDF loader and export logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bdf530f78832a858a71d325e11909