### PR TITLE
Add minimal green terrain demo

### DIFF
--- a/apps/app2/index.html
+++ b/apps/app2/index.html
@@ -1,11 +1,92 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Demo Two</title>
+  <title>Green Terrain</title>
+  <style>
+    html, body { margin: 0; height: 100%; overflow: hidden; }
+    canvas { display: block; }
+  </style>
 </head>
 <body>
-  <h1>Demo Two</h1>
-  <p>This is a placeholder for demo two.</p>
+<script type="module">
+import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+const scene = new THREE.Scene();
+scene.add(new THREE.AmbientLight(0x666666));
+const sunLight = new THREE.DirectionalLight(0xffffff, 1.2);
+sunLight.position.set(260, 220, -500);
+scene.add(sunLight);
+
+const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 3000);
+const controls = { yaw: 0, speed: 60, turnSpeed: Math.PI, height: 60, bounds: 490 };
+camera.position.set(0, controls.height, 160);
+camera.lookAt(0, 0, 0);
+
+const keyState = {};
+window.addEventListener('keydown', e => {
+  if (['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(e.key)) { keyState[e.key] = true; e.preventDefault(); }
+});
+window.addEventListener('keyup', e => {
+  if (['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(e.key)) { keyState[e.key] = false; e.preventDefault(); }
+});
+
+function hash(ix, iz){ const s = Math.sin(ix*127.1 + iz*311.7) * 43758.5453123; return s - Math.floor(s); }
+const lerp = (a,b,t)=> a + (b-a)*t; const smooth = t => t*t*(3-2*t);
+function noise2(x,z){ const ix=Math.floor(x), iz=Math.floor(z), fx=x-ix, fz=z-iz;
+  const a=hash(ix,iz), b=hash(ix+1,iz), c=hash(ix,iz+1), d=hash(ix+1,iz+1);
+  const ux=smooth(fx), uz=smooth(fz); return lerp( lerp(a,b,ux), lerp(c,d,ux), uz ); }
+function fbm(x,z,oct=5){ let amp=1,freq=0.02,sum=0,norm=0; for(let i=0;i<oct;i++){ sum+=amp*noise2(x*freq,z*freq); norm+=amp; amp*=0.5; freq*=2; } return sum/norm; }
+
+const terrain = new THREE.PlaneGeometry(1000,1000,200,200);
+terrain.rotateX(-Math.PI/2);
+const pos = terrain.attributes.position;
+for(let i=0;i<pos.count;i++){ const x=pos.getX(i), z=pos.getZ(i); const y=fbm(x,z)*60-18; pos.setY(i,y); }
+terrain.computeVertexNormals();
+const terrainMesh = new THREE.Mesh(terrain, new THREE.MeshStandardMaterial({ color:0x2a8a4b, flatShading:true, metalness:0, roughness:1 }));
+scene.add(terrainMesh);
+
+function updateControls(dt){
+  if (keyState['ArrowLeft'])  controls.yaw += controls.turnSpeed * dt;
+  if (keyState['ArrowRight']) controls.yaw -= controls.turnSpeed * dt;
+  const forward = new THREE.Vector3(Math.sin(controls.yaw), 0, -Math.cos(controls.yaw));
+  let move = new THREE.Vector3();
+  if (keyState['ArrowUp']) move.add(forward);
+  if (keyState['ArrowDown']) move.add(forward.clone().multiplyScalar(-1));
+  if (move.lengthSq() > 0) {
+    move.normalize().multiplyScalar(controls.speed * dt);
+    const p = camera.position.clone().add(move);
+    p.y = controls.height;
+    p.x = THREE.MathUtils.clamp(p.x, -controls.bounds, controls.bounds);
+    p.z = THREE.MathUtils.clamp(p.z, -controls.bounds, controls.bounds);
+    camera.position.copy(p);
+  }
+  const lookTarget = camera.position.clone().add(forward);
+  camera.lookAt(lookTarget);
+}
+
+let last = performance.now();
+function animate(){
+  const now = performance.now();
+  const dt = Math.min(0.05, (now - last) / 1000);
+  last = now;
+  updateControls(dt);
+  renderer.render(scene, camera);
+  requestAnimationFrame(animate);
+}
+animate();
+
+window.addEventListener('resize', () => {
+  const w = window.innerWidth;
+  const h = window.innerHeight;
+  renderer.setSize(w, h);
+  camera.aspect = w / h;
+  camera.updateProjectionMatrix();
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace placeholder app2 with a Three.js demo showing only a procedural green terrain
- Implement arrow-key navigation for moving around the terrain

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c28649dc4832a81770e8f24fe9b84