### PR TITLE
feat(app2): add thousands of colored blocks

### DIFF
--- a/apps/app2/index.html
+++ b/apps/app2/index.html
@@ -53,9 +53,12 @@ scene.add(terrainMesh);
 const groundRay = new THREE.Raycaster();
 function createBlock(x, z) {
   const size = 5;
+  const hue = Math.random() * 0.16;
+  const saturation = 0.7 + Math.random() * 0.3;
+  const lightness = 0.4 + Math.random() * 0.2;
   const block = new THREE.Mesh(
     new THREE.BoxGeometry(size, size, size),
-    new THREE.MeshStandardMaterial({ color: 0xffa500 })
+    new THREE.MeshStandardMaterial({ color: new THREE.Color().setHSL(hue, saturation, lightness) })
   );
   groundRay.set(new THREE.Vector3(x, 100, z), new THREE.Vector3(0, -1, 0));
   const hit = groundRay.intersectObject(terrainMesh);
@@ -66,7 +69,7 @@ function createBlock(x, z) {
   scene.add(block);
 }
 
-for (let i = 0; i < 40; i++) {
+for (let i = 0; i < 2000; i++) {
   const x = Math.random() * controls.bounds * 2 - controls.bounds;
   const z = Math.random() * controls.bounds * 2 - controls.bounds;
   createBlock(x, z);


### PR DESCRIPTION
## Summary
- Generate blocks with random warm colors on terrain
- Increase block count to 2000 for denser landscape

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c428e1b4c832a8c1848e556721351