### PR TITLE
Add 2000 colored blocks to terrain scene

### DIFF
--- a/apps/app2/index.html
+++ b/apps/app2/index.html
@@ -53,9 +53,10 @@ scene.add(terrainMesh);
 const groundRay = new THREE.Raycaster();
 function createBlock(x, z) {
   const size = 2;
+  const color = new THREE.Color().setHSL(Math.random() * 0.15, 0.9, 0.5 + Math.random() * 0.1);
   const block = new THREE.Mesh(
     new THREE.BoxGeometry(size, size, size),
-    new THREE.MeshStandardMaterial({ color: 0xffa500 })
+    new THREE.MeshStandardMaterial({ color })
   );
   groundRay.set(new THREE.Vector3(x, 100, z), new THREE.Vector3(0, -1, 0));
   const hit = groundRay.intersectObject(terrainMesh);
@@ -66,7 +67,7 @@ function createBlock(x, z) {
   scene.add(block);
 }
 
-for (let i = 0; i < 80; i++) {
+for (let i = 0; i < 2000; i++) {
   const x = Math.random() * controls.bounds * 2 - controls.bounds;
   const z = Math.random() * controls.bounds * 2 - controls.bounds;
   createBlock(x, z);


### PR DESCRIPTION
## Summary
- Generate 2000 terrain blocks in app2 with random red, orange, and yellow shades

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c437f2cd4832aa77b68e8e0da4ec6