### PR TITLE
fix: move doctype before comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <!--
 Version: 0.0.18
 Codename: Celestia
@@ -18,7 +19,6 @@ Change Log:
 - Set console log text to 50% opacity
 - Fixed info panel click issues on meshes
 -->
-<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">


### PR DESCRIPTION
## Summary
- ensure `<!doctype html>` is the first line in `index.html`

## Testing
- `node --check server.js`
- `node --check js/script.js`


------
https://chatgpt.com/codex/tasks/task_e_689c4b903fd0832a8a6d360811172b06