### PR TITLE
feat: add dynamic canvas scaling and update version

### DIFF
--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -95,10 +95,10 @@
   ],
   "status": "Ready.",
   "welcome": {
-    "title": "WebGUI 0.0.18",
+    "title": "WebGUI 0.1.0",
     "lines": [
       "Welcome to WebGUI - Web browser based windows GUI",
-      "Version 0.0.18",
+      "Version 0.1.0",
       "(c) 2025 CyborgsDream"
     ],
     "button": "OK"
@@ -164,7 +164,7 @@
   "windows": {
     "system-info": {
       "title": "System Information",
-      "content": "<h2>WebGUI Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>WebGUI 0.0.18</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Power Without the Price</div></div>",
+      "content": "<h2>WebGUI Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>WebGUI 0.1.0</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Power Without the Price</div></div>",
       "width": 320,
       "height": 300
     },
@@ -176,7 +176,7 @@
     },
     "text-editor": {
       "title": "Text Editor",
-      "content": "<div class=\"text-editor\" style=\"display:flex;flex-direction:column;height:100%\"><div style=\"text-align:right;margin-bottom:5px;\"><button id=\"text-editor-export\" style=\"font-size:16px;\">Export PDF</button></div><textarea id=\"text-editor-area\" style=\"flex:1;background:#fff;border:1px solid #aaa;padding:5px;font-family:monospace;font-size:18px;\">Welcome to WebGUI 0.0.18!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea></div>",
+      "content": "<div class=\"text-editor\" style=\"display:flex;flex-direction:column;height:100%\"><div style=\"text-align:right;margin-bottom:5px;\"><button id=\"text-editor-export\" style=\"font-size:16px;\">Export PDF</button></div><textarea id=\"text-editor-area\" style=\"flex:1;background:#fff;border:1px solid #aaa;padding:5px;font-family:monospace;font-size:18px;\">Welcome to WebGUI 0.1.0!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea></div>",
       "width": 500,
       "height": 350
     },

--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -12,7 +12,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>WebGUI 0.0.18</title>
+    <title>WebGUI 0.1.0</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=VT323&display=swap">
     <style>
         * {

--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/* Version: 0.0.18 */
+/* Version: 0.1.0 */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--
-Version: 0.0.18
+Version: 0.1.0
 Codename: Celestia
 Change Log:
  - Initial responsive boilerplate
@@ -13,7 +13,8 @@ Change Log:
 - Switched object labels to <h3> elements
  - Made info text white for visibility
 - Removed console log background and limited visibility to 3 seconds
- - Bumped version to 0.0.18
+ - Bumped version to 0.1.0
+ - Enabled dynamic 16:9 scaling for larger screens
  - Reduced DEMOS text wave range and limited movement to Z axis
 - Raised demo objects and enabled inter-object shadows
 - Set console log text to 50% opacity
@@ -24,7 +25,7 @@ Change Log:
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Responsive HTML5 Boilerplate</title>
+  <title>DEMOS</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -32,7 +33,7 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
-      <div id="version-number">v0.0.18</div>
+      <div id="version-number">v0.1.0</div>
       <div id="console-log"></div>
       <div id="app-info">
         <span id="close-info" class="close-icon" aria-label="Close">&times;</span>

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,4 @@
-// Version: 0.0.18
+// Version: 0.1.0
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';
@@ -12,20 +12,34 @@ if (consoleLogEl) {
     filter: ['info', 'warn', 'error']
   });
 }
-console.log('Responsive boilerplate loaded');
+console.log('DEMOS loaded');
 
 // Initialize scene
 const container = document.getElementById('scene-container');
+function setContainerSize() {
+  const aspect = 16 / 9;
+  let width = window.innerWidth;
+  let height = window.innerHeight;
+  if (width / height > aspect) {
+    width = height * aspect;
+  } else {
+    height = width / aspect;
+  }
+  container.style.width = `${width}px`;
+  container.style.height = `${height}px`;
+  return { width, height };
+}
 const fpsCounter = document.getElementById('fps-counter');
 const scene = new THREE.Scene();
+const { width: initW, height: initH } = setContainerSize();
 const camera = new THREE.PerspectiveCamera(
   75,
-  container.clientWidth / container.clientHeight,
+  initW / initH,
   0.1,
   1000
 );
 const renderer = new THREE.WebGLRenderer({ antialias: true });
-renderer.setSize(container.clientWidth, container.clientHeight);
+renderer.setSize(initW, initH);
 renderer.setClearColor(0x000033);
 renderer.shadowMap.enabled = true;
 container.appendChild(renderer.domElement);
@@ -353,8 +367,7 @@ container.appendChild(renderer.domElement);
   }
 
   function onWindowResize() {
-    const width = container.clientWidth;
-    const height = container.clientHeight;
+    const { width, height } = setContainerSize();
     camera.aspect = width / height;
     camera.updateProjectionMatrix();
     renderer.setSize(width, height);


### PR DESCRIPTION
## Summary
- Rename page title to DEMOS and bump version to 0.1.0
- Implement dynamic 16:9 canvas scaling for larger screens
- Sync version references across HTML, CSS, JS, and app data

## Testing
- `node server.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689def587698832a937b9f12a77f501e