### PR TITLE
Generate meshes from app list dynamically

### DIFF
--- a/js/scene.js
+++ b/js/scene.js
@@ -69,20 +69,7 @@ export function initScene(container, fpsCounter) {
   console.info('Directional light added');
 
   meshes = [];
-  function createMesh(geometry, color, x, z = 1) {
-    const material = new THREE.MeshStandardMaterial({ color });
-    const mesh = new THREE.Mesh(geometry, material);
-    mesh.position.set(x, 2, z);
-    mesh.castShadow = true;
-    mesh.receiveShadow = true;
-    scene.add(mesh);
-    meshes.push(mesh);
-    return mesh;
-  }
-
-  createMesh(new THREE.IcosahedronGeometry(1.2), 0xff6600, -4);
-  createMesh(new THREE.TorusGeometry(0.9, 0.3, 16, 30), 0x0096d6, 0);
-  console.info('Meshes created', meshes.map(m => m.position));
+  console.info('Meshes initialized');
 
   // Chunky voxel-style DEMOS heading
   const LETTERS = {

--- a/js/script.js
+++ b/js/script.js
@@ -1,9 +1,10 @@
 // Version: 0.1.0
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
+import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';
 import { initConsoleLogs } from '../shared/consolelogs.js';
 import { initLabels, addLabel } from './labels.js';
-import { initScene, meshes, renderer, camera } from './scene.js';
+import { initScene, scene, meshes, renderer, camera } from './scene.js';
 import { initInteraction } from './interaction.js';
 
 const { apps } = await fetch('data/index.json').then(r => r.json());
@@ -23,13 +24,24 @@ const fpsCounter = document.getElementById('fps-counter');
 initLabels(container);
 initScene(container, fpsCounter);
 
-const offsets = [-20, 20];
+const radius = 4;
 apps.forEach((app, i) => {
-  const mesh = meshes[i];
-  if (!mesh) return;
-  const off = offsets[i] || 0;
-  addLabel(mesh, app.name, '#fff', -1, 'object-label', off);
-  addLabel(mesh, app.short, '#fff', -1.5, 'object-info', off);
+  const angle = (i / apps.length) * Math.PI * 2;
+  const x = Math.cos(angle) * radius;
+  const z = Math.sin(angle) * radius;
+  const geometry = i % 2 === 0
+    ? new THREE.IcosahedronGeometry(1.2)
+    : new THREE.TorusGeometry(0.9, 0.3, 16, 30);
+  const color = i % 2 === 0 ? 0xff6600 : 0x0096d6;
+  const mesh = new THREE.Mesh(geometry, new THREE.MeshStandardMaterial({ color }));
+  mesh.position.set(x, 2, z);
+  mesh.castShadow = true;
+  mesh.receiveShadow = true;
+  scene.add(mesh);
+  meshes.push(mesh);
+  const offsetX = x < 0 ? -20 : 20;
+  addLabel(mesh, app.name, '#fff', -1, 'object-label', offsetX);
+  addLabel(mesh, app.short, '#fff', -1.5, 'object-info', offsetX);
 });
 
 initInteraction({ container, renderer, camera, meshes, apps });


### PR DESCRIPTION
## Summary
- Create Three.js meshes per app entry positioned around a circle
- Remove hard-coded mesh array and derive label offsets from mesh positions
- Keep mesh list updated for raycasting selection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a70bf50008832a8c8ad011c6b3ab09