### PR TITLE
feat: persist window state

### DIFF
--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -272,6 +272,7 @@
     }
   },
   "settings": {
-    "clockFormat": "en-US"
+    "clockFormat": "en-US",
+    "persistWindows": true
   }
 }

--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -626,10 +626,12 @@
             windowCount: 0,
             puzzleState: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0]
         };
-        
+
         // DOM references
         const desktop = document.getElementById('desktop');
         let appData = null;
+        let persistWindows = true;
+        let windowStates = JSON.parse(localStorage.getItem('windowStates') || '{}');
 
         function buildMenus(menus) {
             const bar = document.getElementById('menu-bar');
@@ -685,6 +687,17 @@
             appData.icons.forEach(ic => {
                 window.appTypeMap[ic.label.toLowerCase()] = ic.type;
             });
+        }
+
+        function saveWindowState(type, el) {
+            if (!persistWindows || !type) return;
+            windowStates[type] = {
+                top: el.offsetTop,
+                left: el.offsetLeft,
+                width: el.offsetWidth,
+                height: el.offsetHeight
+            };
+            localStorage.setItem('windowStates', JSON.stringify(windowStates));
         }
 
         function preloadAppScripts() {
@@ -784,11 +797,19 @@
 
             const id = `window-${++state.windowCount}`;
             state.zIndex++;
-            const top = 50 + state.windowCount * 20;
-            const left = 50 + state.windowCount * 20;
+            let top = 50 + state.windowCount * 20;
+            let left = 50 + state.windowCount * 20;
+
+            if (persistWindows && windowStates[type]) {
+                const saved = windowStates[type];
+                winWidth = saved.width;
+                winHeight = saved.height;
+                top = saved.top;
+                left = saved.left;
+            }
 
             const windowHtml = `
-                <div class="window" id="${id}"
+                <div class="window" id="${id}" data-window-type="${type}"
                      data-init-width="${winWidth}"
                      data-init-height="${winHeight}"
                      data-init-top="${top}"
@@ -815,6 +836,7 @@
             makeDraggable(id);
             state.windows.push(id);
             updateTaskBar();
+            saveWindowState(type, winEl);
             const iframe = winEl.querySelector('iframe');
             if (iframe) {
                 const loader = document.createElement('div');
@@ -950,6 +972,7 @@
                 }
                 window.style.zIndex = ++state.zIndex;
                 updateTaskBar();
+                saveWindowState(window.dataset.windowType, window);
             }
         }
         
@@ -985,6 +1008,7 @@
             function closeDragElement() {
                 document.onpointerup = null;
                 document.onpointermove = null;
+                saveWindowState(window.dataset.windowType, window);
             }
         }
         
@@ -998,6 +1022,7 @@
         async function init() {
             const res = await fetch('app-data/app1.json');
             appData = await res.json();
+            persistWindows = appData.settings && appData.settings.persistWindows !== false;
             buildMenus(appData.menus);
             buildIcons(appData.icons);
             buildIconTypeMap();


### PR DESCRIPTION
## Summary
- store each window's geometry in localStorage and reapply on creation
- allow users to disable persistence via new `persistWindows` setting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a71b1b2938832a837cfce65d849544