### PR TITLE
Add futuristic theme and skin selector

### DIFF
--- a/apps/app1/app-css/futuristic.css
+++ b/apps/app1/app-css/futuristic.css
@@ -1,0 +1,65 @@
+/* Futuristic theme overrides */
+body {
+  background: #111;
+  color: #eee;
+}
+.desktop {
+  background: #111;
+  border: 1px solid #444;
+  box-shadow: none;
+}
+.desktop::after,
+.desktop::before {
+  content: none;
+}
+.menu-bar {
+  height: 20px;
+  font-size: 14px;
+  background: linear-gradient(to bottom, #222, #111);
+  border-bottom: 1px solid #444;
+}
+.menu-item {
+  margin-right: 10px;
+  padding: 0 4px;
+}
+.dropdown {
+  top: 20px;
+  min-width: 150px;
+}
+.dropdown-item {
+  padding: 3px 8px;
+  font-size: 14px;
+}
+.clock {
+  font-size: 14px;
+}
+.desktop-icons {
+  padding: 10px;
+  gap: 20px;
+}
+.icon {
+  width: 48px;
+}
+.icon .icon-image {
+  font-size: 28px;
+}
+.icon-label {
+  font-size: 14px;
+}
+.window-header {
+  height: 20px;
+  font-size: 14px;
+}
+.window-header .window-title {
+  font-size: 14px;
+}
+.task-bar {
+  height: 20px;
+  font-size: 14px;
+}
+.task-icon {
+  width: 40px;
+}
+button, input, textarea {
+  font-size: 14px;
+}

--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -99,6 +99,13 @@
           "label": "Close All"
         }
       ]
+    },
+    {
+      "label": "Theme",
+      "items": [
+        { "label": "Retro", "action": "set-theme", "theme": "retro" },
+        { "label": "Futuristic", "action": "set-theme", "theme": "futuristic" }
+      ]
     }
   ],
   "status": "Ready.",

--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -580,6 +580,7 @@
         
         /* Icons are now clickable! */
     </style>
+    <link id="theme-link" rel="stylesheet">
 </head>
 <body>
     <div class="desktop" id="desktop">
@@ -633,6 +634,16 @@
         let persistWindows = true;
         let windowStates = JSON.parse(localStorage.getItem('windowStates') || '{}');
 
+        function setTheme(theme) {
+            const link = document.getElementById('theme-link');
+            if (theme === 'retro') {
+                link.removeAttribute('href');
+            } else {
+                link.setAttribute('href', `app-css/${theme}.css`);
+            }
+            localStorage.setItem('theme', theme);
+        }
+
         function buildMenus(menus) {
             const bar = document.getElementById('menu-bar');
             const clock = document.getElementById('clock');
@@ -647,7 +658,9 @@
                     const div = document.createElement('div');
                     div.className = 'dropdown-item';
                     div.textContent = entry.label;
-                    if (entry.type) {
+                    if (entry.action === 'set-theme' && entry.theme) {
+                        div.addEventListener('click', () => setTheme(entry.theme));
+                    } else if (entry.type) {
                         div.setAttribute('onclick', `openWindow('${entry.type}')`);
                     }
                     dropdown.appendChild(div);
@@ -1022,6 +1035,7 @@
         async function init() {
             const res = await fetch('app-data/app1.json');
             appData = await res.json();
+            setTheme(localStorage.getItem('theme') || 'retro');
             persistWindows = appData.settings && appData.settings.persistWindows !== false;
             buildMenus(appData.menus);
             buildIcons(appData.icons);


### PR DESCRIPTION
## Summary
- add Theme menu entries for Retro and Futuristic skins
- implement theme switching with persistent selection
- introduce Futuristic theme stylesheet with compact modern styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa337c1de4832ab6cd1c65b739a330