### PR TITLE
Add theme selection dialog after system name

### DIFF
--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -610,6 +610,32 @@
         <div class="task-bar" id="task-bar"></div>
         <div class="taskbar-menu" id="taskbar-menu" style="display:none;"></div>
         
+        <!-- System name dialog -->
+        <div class="dialog" id="system-name-dialog" style="display:none;">
+            <div class="window-header">
+                <div class="window-title">System Name</div>
+            </div>
+            <div class="dialog-content">
+                <input id="system-name-input" type="text" style="width:80%;" placeholder="Enter system name">
+                <div class="dialog-buttons">
+                    <div class="dialog-btn" id="system-name-ok">OK</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Theme selection dialog -->
+        <div class="dialog" id="theme-dialog" style="display:none;">
+            <div class="window-header">
+                <div class="window-title">Select Theme</div>
+            </div>
+            <div class="dialog-content">
+                <div class="dialog-buttons">
+                    <div class="dialog-btn" data-theme="retro">Retro</div>
+                    <div class="dialog-btn" data-theme="futuristic">Futuristic</div>
+                </div>
+            </div>
+        </div>
+
         <!-- Welcome dialog -->
         <div class="dialog" id="welcome-dialog" style="display:none;">
             <div class="window-header">
@@ -1027,15 +1053,47 @@
         
         
         // Dialog functions
+        function askSystemName() {
+            return new Promise(resolve => {
+                const dialog = document.getElementById('system-name-dialog');
+                dialog.style.display = 'block';
+                document.getElementById('system-name-ok').onclick = () => {
+                    const name = document.getElementById('system-name-input').value.trim();
+                    if (name) {
+                        localStorage.setItem('systemName', name);
+                    }
+                    closeDialog('system-name-dialog');
+                    resolve(name);
+                };
+            });
+        }
+
+        function selectThemeDialog() {
+            return new Promise(resolve => {
+                const dialog = document.getElementById('theme-dialog');
+                dialog.style.display = 'block';
+                dialog.querySelectorAll('.dialog-btn').forEach(btn => {
+                    btn.onclick = () => {
+                        const theme = btn.dataset.theme;
+                        setTheme(theme);
+                        closeDialog('theme-dialog');
+                        resolve(theme);
+                    };
+                });
+            });
+        }
+
         function closeDialog(id) {
             document.getElementById(id).style.display = 'none';
         }
         
         // Initialize everything
         async function init() {
+            setTheme('retro');
+            await askSystemName();
+            await selectThemeDialog();
             const res = await fetch('app-data/app1.json');
             appData = await res.json();
-            setTheme(localStorage.getItem('theme') || 'retro');
             persistWindows = appData.settings && appData.settings.persistWindows !== false;
             buildMenus(appData.menus);
             buildIcons(appData.icons);


### PR DESCRIPTION
## Summary
- Introduce initial system-name prompt and theme selection dialog for WebGUI
- Apply chosen theme before loading remaining UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa385f244c832a9ee690178e3c7727