### PR TITLE
Add futuristic theme and app overrides

### DIFF
--- a/apps/app1/app-css/retro-list-futuristic.css
+++ b/apps/app1/app-css/retro-list-futuristic.css
@@ -1,0 +1,14 @@
+:root{
+  --bg:#000;
+  --panel:#001a33;
+  --ink:#0ff;
+  --muted:#08f;
+  --accent:#f0f;
+  --ok:#0f0;
+  --warn:#ff0;
+  --err:#f66;
+  --line:#033;
+}
+body{background:var(--bg);color:var(--ink);font-size:12px;}
+.btn{padding:.4rem .7rem;font-size:.8rem;}
+input[type="password"],input[type="text"],textarea{font-size:.8rem;}

--- a/apps/app1/app-css/retro-list-light.css
+++ b/apps/app1/app-css/retro-list-light.css
@@ -1,0 +1,12 @@
+:root{
+  --bg:#fdfdfd;
+  --panel:#ffffff;
+  --ink:#000;
+  --muted:#555;
+  --accent:#007acc;
+  --ok:#0a0;
+  --warn:#c08000;
+  --err:#d00;
+  --line:#ccc;
+}
+body{background:var(--bg);color:var(--ink);} 

--- a/apps/app1/retro-list.html
+++ b/apps/app1/retro-list.html
@@ -62,6 +62,20 @@
   .mono{white-space:pre-wrap; word-break:break-word}
   .foot{color:var(--muted); opacity:.85; margin:.6rem 0 0}
 </style>
+<script>
+const theme = localStorage.getItem("theme");
+if(theme === "light"){
+  const link=document.createElement("link");
+  link.rel="stylesheet";
+  link.href="app-css/retro-list-light.css";
+  document.head.appendChild(link);
+}else if(theme === "futuristic"){
+  const link=document.createElement("link");
+  link.rel="stylesheet";
+  link.href="app-css/retro-list-futuristic.css";
+  document.head.appendChild(link);
+}
+</script>
 </head>
 <body>
   <div class="wrap">

--- a/css/style-futuristic.css
+++ b/css/style-futuristic.css
@@ -1,0 +1,247 @@
+/* Version: 0.1.0 */
+/* Codename: Celestia */
+/* Basic responsive CSS */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Orbitron', sans-serif;
+  line-height: 1.6;
+  color: #0ff;
+  font-size: 12px;
+  background: #000;
+  min-height: calc(var(--vh, 1vh) * 100);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+main {
+  padding: 1rem;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#scene-container {
+  position: relative;
+  width: 848px;
+  height: 420px;
+  margin: 0 auto;
+  overflow: hidden;
+}
+
+#fps-counter {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  z-index: 10;
+  color: #0ff;
+  background: rgba(0, 0, 0, 0.5);
+  padding: 2px 4px;
+  font-size: 0.6rem;
+  pointer-events: none;
+  overflow-wrap: anywhere;
+}
+
+#version-number {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  z-index: 10;
+  color: #0ff;
+  background: rgba(0, 0, 0, 0.5);
+  padding: 2px 4px;
+  font-size: 0.6rem;
+  pointer-events: none;
+  overflow-wrap: anywhere;
+}
+
+#console-log {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  max-height: 100px;
+  overflow-y: auto;
+  color: #0ff;
+  background: none;
+  text-shadow: 0 0 5px #0ff;
+  font-family: monospace;
+  font-size: 0.5rem;
+  padding: 2px 4px;
+  pointer-events: none;
+  z-index: 30;
+  overflow-wrap: anywhere;
+}
+
+#console-log .console-line {
+  background: none;
+  opacity: 0.5;
+  animation: fade-out 0.5s ease-out 2.5s forwards;
+}
+
+@keyframes fade-out {
+  to {
+    opacity: 0;
+  }
+}
+#cinematic-heading {
+  position: absolute;
+  top: 20px;
+  width: 100%;
+  text-align: center;
+  font-size: clamp(1rem, 6vw, 3rem);
+  letter-spacing: 0.3rem;
+  color: #fff;
+  text-shadow: 0 0 10px rgba(255, 255, 255, 0.8);
+  font-weight: bold;
+  pointer-events: none;
+  z-index: 20;
+  text-transform: uppercase;
+  overflow-wrap: anywhere;
+  display: none; /* replaced by 3D text */
+}
+#bottom-text {
+  position: absolute;
+  bottom: 10px;
+  width: 100%;
+  text-align: center;
+  font-size: 0.6rem;
+  color: #0ff;
+  pointer-events: none;
+  z-index: 20;
+  overflow-wrap: anywhere;
+}
+#scene-container canvas {
+  background: #000033;
+  display: block;
+}
+
+#scene-container:fullscreen {
+  width: 100vw;
+  height: 100vh;
+}
+#scene-container:-webkit-full-screen {
+  width: 100vw;
+  height: 100vh;
+}
+
+@media (max-width: 848px), (orientation: portrait) {
+  #scene-container {
+    width: 100%;
+    height: calc(100vw * 420 / 848);
+  }
+}
+
+@media (min-width: 768px) {
+  main {
+    padding: 2rem;
+  }
+}
+
+.object-label,
+.object-info {
+  position: absolute;
+  pointer-events: none;
+  font-family: monospace;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  z-index: 40;
+  left: 0;
+  top: 0;
+}
+
+.object-label {
+  font-size: 0.7rem;
+  color: #fff;
+  margin: 0;
+  font-weight: bold;
+}
+.object-label span {
+  display: inline-block;
+}
+
+.object-info {
+  font-size: 0.55rem;
+  color: #fff;
+}
+
+#app-info {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  padding: 1.5rem;
+  max-width: 400px;
+  text-align: center;
+  z-index: 50;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  display: none;
+  opacity: 0;
+  transition: opacity 1s;
+}
+
+#app-info.visible {
+  display: block;
+  opacity: 1;
+}
+
+#app-info .close-icon {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  cursor: pointer;
+  font-size: 1.2rem;
+  opacity: 0.8;
+  transition: transform 0.1s, opacity 0.1s;
+}
+
+#app-info .close-icon:hover {
+  opacity: 1;
+}
+
+#app-info .close-icon:active {
+  transform: scale(0.9);
+}
+
+#app-info button {
+  margin-top: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  transition: transform 0.1s;
+}
+
+#app-info button:active {
+  transform: scale(0.95);
+}
+
+#theme-selection {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  z-index: 100;
+  color: #0ff;
+}
+
+#theme-selection button {
+  margin: 0.5rem;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  background:#000;
+  border:1px solid #0ff;
+  color:#0ff;
+}

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@ Change Log:
     <h2>Select Theme</h2>
     <button data-theme="dark">Dark</button>
     <button data-theme="light">Light</button>
+      <button data-theme="futuristic">Futuristic</button>
   </div>
   <main>
     <div id="scene-container">

--- a/js/script.js
+++ b/js/script.js
@@ -14,17 +14,21 @@ function selectTheme() {
     selector.querySelectorAll('button').forEach(btn => {
       btn.addEventListener('click', () => {
         const theme = btn.dataset.theme;
-        const link = document.getElementById('theme-link');
-        link.href = theme === 'light' ? 'css/style-light.css' : 'css/style.css';
-        selector.style.display = 'none';
-        resolve(theme);
+          const link = document.getElementById('theme-link');
+          let href = 'css/style.css';
+          if (theme === 'light') href = 'css/style-light.css';
+          else if (theme === 'futuristic') href = 'css/style-futuristic.css';
+          link.href = href;
+          localStorage.setItem('theme', theme);
+          selector.style.display = 'none';
+          resolve(theme);
       });
     });
   });
 }
 
 const theme = await selectTheme();
-const labelColor = theme === 'light' ? '#000' : '#fff';
+const labelColor = theme === 'light' ? '#000' : theme === 'futuristic' ? '#0ff' : '#fff';
 
 const { apps } = await fetch('data/index.json').then(r => r.json());
 const consoleLogEl = document.getElementById('console-log');


### PR DESCRIPTION
## Summary
- Introduce super futuristic site theme with smaller fonts and neon palette
- Provide theme-specific styles for RETRO-LIST prompt editor
- Store selected theme and allow choosing new "Futuristic" option

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa489c7168832ab7f64da3bc408720