### PR TITLE
Persist theme choice and fix demo listing

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=index.html">
+  <title>Redirecting...</title>
+</head>
+<body>
+  <p>Redirecting to <a href="index.html">index.html</a>...</p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -27,6 +27,15 @@ Change Log:
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DEMOS</title>
   <link id="theme-link" rel="stylesheet" href="css/style.css">
+  <script>
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme) {
+      let href = 'css/style.css';
+      if (storedTheme === 'light') href = 'css/style-light.css';
+      else if (storedTheme === 'futuristic') href = 'css/style-futuristic.css';
+      document.getElementById('theme-link').href = href;
+    }
+  </script>
 </head>
 <body>
   <div id="theme-selection">

--- a/js/script.js
+++ b/js/script.js
@@ -7,6 +7,14 @@ import { initLabels, addLabel } from './labels.js';
 import { initScene, scene, meshes, renderer, camera } from './scene.js';
 import { initInteraction } from './interaction.js';
 
+function applyTheme(theme) {
+  const link = document.getElementById('theme-link');
+  let href = 'css/style.css';
+  if (theme === 'light') href = 'css/style-light.css';
+  else if (theme === 'futuristic') href = 'css/style-futuristic.css';
+  link.href = href;
+}
+
 function selectTheme() {
   return new Promise(resolve => {
     const selector = document.getElementById('theme-selection');
@@ -14,20 +22,21 @@ function selectTheme() {
     selector.querySelectorAll('button').forEach(btn => {
       btn.addEventListener('click', () => {
         const theme = btn.dataset.theme;
-          const link = document.getElementById('theme-link');
-          let href = 'css/style.css';
-          if (theme === 'light') href = 'css/style-light.css';
-          else if (theme === 'futuristic') href = 'css/style-futuristic.css';
-          link.href = href;
-          localStorage.setItem('theme', theme);
-          selector.style.display = 'none';
-          resolve(theme);
+        applyTheme(theme);
+        localStorage.setItem('theme', theme);
+        selector.style.display = 'none';
+        resolve(theme);
       });
     });
   });
 }
 
-const theme = await selectTheme();
+let theme = localStorage.getItem('theme');
+if (!theme) {
+  theme = await selectTheme();
+} else {
+  applyTheme(theme);
+}
 const labelColor = theme === 'light' ? '#000' : theme === 'futuristic' ? '#0ff' : '#fff';
 
 const { apps } = await fetch('data/index.json').then(r => r.json());
@@ -47,7 +56,7 @@ if (demoList) {
     const li = document.createElement('li');
     const a = document.createElement('a');
     a.href = app.file;
-    a.textContent = app.file;
+    a.textContent = app.name;
     li.appendChild(a);
     demoList.appendChild(li);
   });


### PR DESCRIPTION
## Summary
- Redirect `index.htm` to `index.html` so the entry page loads reliably
- Persist theme selection and apply saved theme on the landing page
- Show demo names in the selectable list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4f5c6ea0832ab913083e1a122fa4