### PR TITLE
feat: add terrain loader demo

### DIFF
--- a/apps/app3/index.html
+++ b/apps/app3/index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Terrain</title>
+  <style>
+    html, body { margin: 0; height: 100%; overflow: hidden; }
+    canvas { display: block; }
+    #loader {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #000;
+      color: #fff;
+      font-family: sans-serif;
+      font-size: 2em;
+    }
+  </style>
+</head>
+<body>
+<div id="loader">Loading <span id="progress">0%</span></div>
+<script type="module">
+import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+
+const loaderEl = document.getElementById('loader');
+const progressEl = document.getElementById('progress');
+function setProgress(p){ progressEl.textContent = Math.round(p) + '%'; }
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+const scene = new THREE.Scene();
+scene.add(new THREE.AmbientLight(0x666666));
+const sunLight = new THREE.DirectionalLight(0xffffff, 1.2);
+sunLight.position.set(260, 220, -500);
+scene.add(sunLight);
+
+const camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 0.1, 3000);
+const controls = { yaw: 0, speed: 60, turnSpeed: Math.PI, height: 60, bounds: 290 };
+camera.position.set(0, controls.height, 160);
+camera.lookAt(0, 0, 0);
+
+const keyState = {};
+window.addEventListener('keydown', e => {
+  if (['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(e.key)) { keyState[e.key] = true; e.preventDefault(); }
+});
+window.addEventListener('keyup', e => {
+  if (['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(e.key)) { keyState[e.key] = false; e.preventDefault(); }
+});
+
+let touchStart = null;
+window.addEventListener('touchstart', e => {
+  touchStart = e.touches[0];
+  e.preventDefault();
+});
+window.addEventListener('touchmove', e => {
+  if (!touchStart) return;
+  const touch = e.touches[0];
+  const dx = touch.clientX - touchStart.clientX;
+  const dy = touch.clientY - touchStart.clientY;
+  const threshold = 10;
+  keyState['ArrowLeft'] = dx < -threshold;
+  keyState['ArrowRight'] = dx > threshold;
+  keyState['ArrowUp'] = dy < -threshold;
+  keyState['ArrowDown'] = dy > threshold;
+  e.preventDefault();
+});
+window.addEventListener('touchend', e => {
+  touchStart = null;
+  keyState['ArrowLeft'] = keyState['ArrowRight'] = keyState['ArrowUp'] = keyState['ArrowDown'] = false;
+  e.preventDefault();
+});
+
+function hash(ix, iz){ const s = Math.sin(ix*127.1 + iz*311.7) * 43758.5453123; return s - Math.floor(s); }
+const lerp = (a,b,t)=> a + (b-a)*t; const smooth = t => t*t*(3-2*t);
+function noise2(x,z){ const ix=Math.floor(x), iz=Math.floor(z), fx=x-ix, fz=z-iz;
+  const a=hash(ix,iz), b=hash(ix+1,iz), c=hash(ix,iz+1), d=hash(ix+1,iz+1);
+  const ux=smooth(fx), uz=smooth(fz); return lerp( lerp(a,b,ux), lerp(c,d,ux), uz ); }
+function fbm(x,z,oct=5){ let amp=1,freq=0.02,sum=0,norm=0; for(let i=0;i<oct;i++){ sum+=amp*noise2(x*freq,z*freq); norm+=amp; amp*=0.5; freq*=2; } return sum/norm; }
+
+const terrain = new THREE.PlaneGeometry(600,600,120,120);
+terrain.rotateX(-Math.PI/2);
+const pos = terrain.attributes.position;
+for(let i=0;i<pos.count;i++){ const x=pos.getX(i), z=pos.getZ(i); const y=fbm(x,z)*60-18; pos.setY(i,y); }
+terrain.computeVertexNormals();
+const terrainMesh = new THREE.Mesh(terrain, new THREE.MeshStandardMaterial({ color:0x2a8a4b, flatShading:true, metalness:0, roughness:1 }));
+scene.add(terrainMesh);
+
+const groundRay = new THREE.Raycaster();
+function createBlock(x, z) {
+  const size = 2;
+  const color = new THREE.Color().setHSL(Math.random() * 0.15, 0.9, 0.5 + Math.random() * 0.1);
+  const block = new THREE.Mesh(
+    new THREE.BoxGeometry(size, size, size),
+    new THREE.MeshStandardMaterial({ color })
+  );
+  groundRay.set(new THREE.Vector3(x, 100, z), new THREE.Vector3(0, -1, 0));
+  const hit = groundRay.intersectObject(terrainMesh);
+  const y = hit.length ? hit[0].point.y : 0;
+  block.position.set(x, y + size / 2, z);
+  block.castShadow = true;
+  block.receiveShadow = true;
+  scene.add(block);
+}
+
+async function generateBlocks(count) {
+  for (let i = 0; i < count; i++) {
+    const x = Math.random() * controls.bounds * 2 - controls.bounds;
+    const z = Math.random() * controls.bounds * 2 - controls.bounds;
+    createBlock(x, z);
+    if (i % 50 === 0) {
+      setProgress((i / count) * 100);
+      await new Promise(requestAnimationFrame);
+    }
+  }
+  setProgress(100);
+  loaderEl.remove();
+}
+
+function updateControls(dt){
+  if (keyState['ArrowLeft'])  controls.yaw -= controls.turnSpeed * dt;
+  if (keyState['ArrowRight']) controls.yaw += controls.turnSpeed * dt;
+  const forward = new THREE.Vector3(Math.sin(controls.yaw), 0, -Math.cos(controls.yaw));
+  let move = new THREE.Vector3();
+  if (keyState['ArrowUp']) move.add(forward);
+  if (keyState['ArrowDown']) move.add(forward.clone().multiplyScalar(-1));
+  if (move.lengthSq() > 0) {
+    move.normalize().multiplyScalar(controls.speed * dt);
+    const p = camera.position.clone().add(move);
+    p.y = controls.height;
+    p.x = THREE.MathUtils.clamp(p.x, -controls.bounds, controls.bounds);
+    p.z = THREE.MathUtils.clamp(p.z, -controls.bounds, controls.bounds);
+    camera.position.copy(p);
+  }
+  const lookTarget = camera.position.clone().add(forward);
+  camera.lookAt(lookTarget);
+}
+
+let last = performance.now();
+function animate(){
+  const now = performance.now();
+  const dt = Math.min(0.05, (now - last) / 1000);
+  last = now;
+  updateControls(dt);
+  renderer.render(scene, camera);
+  requestAnimationFrame(animate);
+}
+
+await generateBlocks(1000);
+animate();
+
+window.addEventListener('resize', () => {
+  const w = window.innerWidth;
+  const h = window.innerHeight;
+  renderer.setSize(w, h);
+  camera.aspect = w / h;
+  camera.updateProjectionMatrix();
+});
+</script>
+</body>
+</html>
+

--- a/data/index.json
+++ b/data/index.json
@@ -6,18 +6,25 @@
       "short": "lorem ipsum doloret sit amet",
       "long": "This is the first demo showcasing features."
     },
-    {
-      "name": "Demo Two",
-      "file": "apps/app2/index.html",
-      "short": "lorem ipsum doloret sit amet",
-      "long": "This is the second demo showcasing features."
-    }
-    ,
-    {
-      "name": "Universe",
-      "file": "apps/universe/index.html",
-      "short": "Hyperluminal celestial terrain demo",
-      "long": "Explore galaxies, nebulae, lensing effects and a black hole."
-    }
+      {
+        "name": "Demo Two",
+        "file": "apps/app2/index.html",
+        "short": "lorem ipsum doloret sit amet",
+        "long": "This is the second demo showcasing features."
+      }
+      ,
+      {
+        "name": "Demo Three",
+        "file": "apps/app3/index.html",
+        "short": "lorem ipsum doloret sit amet",
+        "long": "This is the third demo showcasing features."
+      }
+      ,
+      {
+        "name": "Universe",
+        "file": "apps/universe/index.html",
+        "short": "Hyperluminal celestial terrain demo",
+        "long": "Explore galaxies, nebulae, lensing effects and a black hole."
+      }
   ]
 }


### PR DESCRIPTION
## Summary
- duplicate app2 as new app3
- show loading overlay with progress while terrain blocks spawn
- shrink terrain and tweak camera for a closer view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af63363c20832abe9efe96a3cc7625