### PR TITLE
Ensure 16:9 layout and adjust scene composition

### DIFF
--- a/css/style-futuristic.css
+++ b/css/style-futuristic.css
@@ -12,7 +12,7 @@ body {
   line-height: 1.6;
   color: #0ff;
   font-size: 12px;
-  background: #000;
+  background: #001533;
   min-height: calc(var(--vh, 1vh) * 100);
   display: flex;
   flex-direction: column;
@@ -29,10 +29,12 @@ main {
 
 #scene-container {
   position: relative;
-  width: 848px;
-  height: 420px;
+  width: 960px;
+  height: 540px;
+  aspect-ratio: 16 / 9;
   margin: 0 auto;
   overflow: hidden;
+  background: #001533;
 }
 
 #fps-counter {
@@ -143,7 +145,7 @@ main {
   overflow-wrap: anywhere;
 }
 #scene-container canvas {
-  background: #000033;
+  background: #001533;
   display: block;
 }
 
@@ -159,7 +161,7 @@ main {
 @media (max-width: 848px), (orientation: portrait) {
   #scene-container {
     width: 100%;
-    height: calc(100vw * 420 / 848);
+    height: calc(100vw * 9 / 16);
   }
 }
 

--- a/css/style-light.css
+++ b/css/style-light.css
@@ -11,7 +11,7 @@ body {
   font-family: Arial, sans-serif;
   line-height: 1.6;
   color: #333;
-  background: #000;
+  background: #001533;
   min-height: calc(var(--vh, 1vh) * 100);
   display: flex;
   flex-direction: column;
@@ -28,10 +28,12 @@ main {
 
 #scene-container {
   position: relative;
-  width: 848px;
-  height: 420px;
+  width: 960px;
+  height: 540px;
+  aspect-ratio: 16 / 9;
   margin: 0 auto;
   overflow: hidden;
+  background: #001533;
 }
 
 #fps-counter {
@@ -142,7 +144,7 @@ main {
   overflow-wrap: anywhere;
 }
 #scene-container canvas {
-  background: #000033;
+  background: #001533;
   display: block;
 }
 
@@ -158,7 +160,7 @@ main {
 @media (max-width: 848px), (orientation: portrait) {
   #scene-container {
     width: 100%;
-    height: calc(100vw * 420 / 848);
+    height: calc(100vw * 9 / 16);
   }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -11,7 +11,7 @@ body {
   font-family: Arial, sans-serif;
   line-height: 1.6;
   color: #333;
-  background: #000;
+  background: #001533;
   min-height: calc(var(--vh, 1vh) * 100);
   display: flex;
   flex-direction: column;
@@ -28,10 +28,12 @@ main {
 
 #scene-container {
   position: relative;
-  width: 848px;
-  height: 420px;
+  width: 960px;
+  height: 540px;
+  aspect-ratio: 16 / 9;
   margin: 0 auto;
   overflow: hidden;
+  background: #001533;
 }
 
 #fps-counter {
@@ -142,7 +144,7 @@ main {
   overflow-wrap: anywhere;
 }
 #scene-container canvas {
-  background: #000033;
+  background: #001533;
   display: block;
 }
 
@@ -158,7 +160,7 @@ main {
 @media (max-width: 848px), (orientation: portrait) {
   #scene-container {
     width: 100%;
-    height: calc(100vw * 420 / 848);
+    height: calc(100vw * 9 / 16);
   }
 }
 

--- a/js/scene.js
+++ b/js/scene.js
@@ -9,13 +9,31 @@ export let meshes;
 export function initScene(container, fpsCounter) {
   function setContainerSize() {
     const aspect = 16 / 9;
-    let width = window.innerWidth;
-    let height = window.innerHeight;
-    if (width / height > aspect) {
-      width = height * aspect;
-    } else {
-      height = width / aspect;
+    const parent = container.parentElement;
+    let maxWidth = window.innerWidth;
+    let maxHeight = window.innerHeight;
+
+    if (parent) {
+      const styles = window.getComputedStyle(parent);
+      const paddingX = (parseFloat(styles.paddingLeft) || 0) + (parseFloat(styles.paddingRight) || 0);
+      const paddingY = (parseFloat(styles.paddingTop) || 0) + (parseFloat(styles.paddingBottom) || 0);
+      const parentWidth = parent.clientWidth - paddingX;
+      const parentHeight = parent.clientHeight - paddingY;
+      if (parentWidth > 0) {
+        maxWidth = Math.min(maxWidth, parentWidth);
+      }
+      if (parentHeight > 0) {
+        maxHeight = Math.min(maxHeight, parentHeight);
+      }
     }
+
+    let width = maxWidth;
+    let height = width / aspect;
+    if (height > maxHeight) {
+      height = maxHeight;
+      width = height * aspect;
+    }
+
     container.style.width = `${width}px`;
     container.style.height = `${height}px`;
     return { width, height };
@@ -26,7 +44,7 @@ export function initScene(container, fpsCounter) {
   camera = new THREE.PerspectiveCamera(60, initW / initH, 0.1, 1000);
   renderer = new THREE.WebGLRenderer({ antialias: true });
   renderer.setSize(initW, initH);
-  renderer.setClearColor(0x000033);
+  renderer.setClearColor(0x001533);
   renderer.shadowMap.enabled = true;
   container.appendChild(renderer.domElement);
 
@@ -141,8 +159,8 @@ export function initScene(container, fpsCounter) {
       letter.userData.initialZ = letter.position.z;
       letter.userData.phase = Math.random() * Math.PI * 2;
     });
-    group.scale.set(2 / 3, 2 / 3, 2 / 3);
-    group.position.set(0, 4.35, 0.5);
+    group.scale.set(0.55, 0.55, 0.55);
+    group.position.set(0, 4, 0.5);
     group.rotation.x = 0;
     return group;
   }
@@ -151,7 +169,7 @@ export function initScene(container, fpsCounter) {
   scene.add(textMesh);
   console.info('Voxel text added', textMesh.position);
 
-  camera.position.set(0, 6, 3);
+  camera.position.set(0, 7.5, 5);
   camera.lookAt(0, 2, 0);
 
   let lastTime;

--- a/js/script.js
+++ b/js/script.js
@@ -84,7 +84,8 @@ head.position.y = 1.6;
 head.castShadow = true;
 character.add(body);
 character.add(head);
-character.position.set(0, 1.5, 2);
+character.scale.setScalar(0.7);
+character.position.set(0, 1.2, 2.8);
 scene.add(character);
 
 const radius = 4;
@@ -93,11 +94,11 @@ apps.forEach((app, i) => {
   const x = Math.cos(angle) * radius;
   const z = Math.sin(angle) * radius;
   const geometry = i % 2 === 0
-    ? new THREE.IcosahedronGeometry(1.2)
-    : new THREE.TorusGeometry(0.9, 0.3, 16, 30);
+    ? new THREE.IcosahedronGeometry(0.85)
+    : new THREE.TorusGeometry(0.65, 0.2, 16, 30);
   const color = i % 2 === 0 ? 0xff6600 : 0x0096d6;
   const mesh = new THREE.Mesh(geometry, new THREE.MeshStandardMaterial({ color }));
-  mesh.position.set(x, 2, z);
+  mesh.position.set(x, 1.7, z);
   mesh.castShadow = true;
   mesh.receiveShadow = true;
   scene.add(mesh);


### PR DESCRIPTION
## Summary
- enforce a fixed 16:9 presentation and dark navy surroundings for the scene canvas across themes
- update the renderer sizing helper to respect parent dimensions and match the navy clear color
- reduce mesh, character, and voxel text scale while moving the camera further back for a wider view

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca48b4ef1c832a963ee7ab611c4d4b