### PR TITLE
Refine layout and controls for demo selection

### DIFF
--- a/css/style-futuristic.css
+++ b/css/style-futuristic.css
@@ -7,6 +7,13 @@
   box-sizing: border-box;
 }
 
+html,
+body {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
 body {
   font-family: 'Orbitron', sans-serif;
   line-height: 1.6;
@@ -20,11 +27,14 @@ body {
 }
 
 main {
-  padding: 1rem;
+  padding: clamp(0.5rem, 2vw, 1.25rem);
   flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 100%;
+  min-height: 0;
+  overflow: hidden;
 }
 
 #scene-container {
@@ -32,9 +42,11 @@ main {
   width: 960px;
   height: 540px;
   aspect-ratio: 16 / 9;
-  margin: 0 auto;
+  margin: 0;
   overflow: hidden;
   background: #001533;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 #fps-counter {
@@ -65,27 +77,54 @@ main {
 
 #demo-files {
   position: absolute;
-  top: 40px;
-  right: 10px;
+  top: 16px;
+  left: 16px;
   z-index: 20;
   color: #0ff;
-  background: rgba(0, 0, 0, 0.6);
-  padding: 0.5rem;
-  border-radius: 4px;
-  font-size: 0.6rem;
+  background: rgba(0, 0, 0, 0.65);
+  padding: 0.75rem;
+  border-radius: 8px;
+  font-size: 0.7rem;
+  width: clamp(160px, 24%, 220px);
+  max-height: calc(100% - 32px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  overflow: hidden;
 }
 
 #demo-files h2 {
-  font-size: 0.8rem;
-  margin-bottom: 0.5rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15rem;
+  margin: 0;
 }
 
 #demo-files ul {
   list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+  flex: 1;
+  min-height: 0;
 }
 
-#demo-files li + li {
-  margin-top: 0.25rem;
+#demo-files li a {
+  color: inherit;
+  text-decoration: none;
+  padding: 0.35rem 0.4rem;
+  border-radius: 4px;
+  background: rgba(0, 255, 255, 0.08);
+  transition: background 0.2s ease, transform 0.2s ease;
+  display: block;
+}
+
+#demo-files li a:hover,
+#demo-files li a:focus-visible {
+  background: rgba(0, 255, 255, 0.2);
+  transform: translateX(2px);
 }
 
 #console-log {

--- a/css/style-light.css
+++ b/css/style-light.css
@@ -7,6 +7,13 @@
   box-sizing: border-box;
 }
 
+html,
+body {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
 body {
   font-family: Arial, sans-serif;
   line-height: 1.6;
@@ -19,11 +26,14 @@ body {
 }
 
 main {
-  padding: 1rem;
+  padding: clamp(0.5rem, 2vw, 1.25rem);
   flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 100%;
+  min-height: 0;
+  overflow: hidden;
 }
 
 #scene-container {
@@ -31,9 +41,11 @@ main {
   width: 960px;
   height: 540px;
   aspect-ratio: 16 / 9;
-  margin: 0 auto;
+  margin: 0;
   overflow: hidden;
   background: #001533;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 #fps-counter {
@@ -64,27 +76,52 @@ main {
 
 #demo-files {
   position: absolute;
-  top: 40px;
-  right: 10px;
+  top: 16px;
+  left: 16px;
   z-index: 20;
   color: #fff;
   background: rgba(0, 0, 0, 0.6);
-  padding: 0.5rem;
-  border-radius: 4px;
-  font-size: 0.8rem;
+  padding: 0.75rem;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  width: clamp(160px, 24%, 240px);
+  max-height: calc(100% - 32px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  overflow: hidden;
 }
 
 #demo-files h2 {
   font-size: 1rem;
-  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  margin: 0;
 }
 
 #demo-files ul {
   list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+  flex: 1;
+  min-height: 0;
 }
 
-#demo-files li + li {
-  margin-top: 0.25rem;
+#demo-files li a {
+  color: inherit;
+  text-decoration: none;
+  padding: 0.3rem 0.4rem;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.16);
+  transition: background 0.2s ease;
+  display: block;
+}
+
+#demo-files li a:hover,
+#demo-files li a:focus-visible {
+  background: rgba(255, 255, 255, 0.28);
 }
 
 #console-log {

--- a/css/style.css
+++ b/css/style.css
@@ -7,6 +7,13 @@
   box-sizing: border-box;
 }
 
+html,
+body {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
 body {
   font-family: Arial, sans-serif;
   line-height: 1.6;
@@ -19,11 +26,14 @@ body {
 }
 
 main {
-  padding: 1rem;
+  padding: clamp(0.5rem, 2vw, 1.25rem);
   flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 100%;
+  min-height: 0;
+  overflow: hidden;
 }
 
 #scene-container {
@@ -31,9 +41,11 @@ main {
   width: 960px;
   height: 540px;
   aspect-ratio: 16 / 9;
-  margin: 0 auto;
+  margin: 0;
   overflow: hidden;
   background: #001533;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 #fps-counter {
@@ -64,27 +76,52 @@ main {
 
 #demo-files {
   position: absolute;
-  top: 40px;
-  right: 10px;
+  top: 16px;
+  left: 16px;
   z-index: 20;
   color: #fff;
   background: rgba(0, 0, 0, 0.6);
-  padding: 0.5rem;
-  border-radius: 4px;
-  font-size: 0.8rem;
+  padding: 0.75rem;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  width: clamp(160px, 24%, 240px);
+  max-height: calc(100% - 32px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  overflow: hidden;
 }
 
 #demo-files h2 {
   font-size: 1rem;
-  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  margin: 0;
 }
 
 #demo-files ul {
   list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+  flex: 1;
+  min-height: 0;
 }
 
-#demo-files li + li {
-  margin-top: 0.25rem;
+#demo-files li a {
+  color: inherit;
+  text-decoration: none;
+  padding: 0.3rem 0.4rem;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.08);
+  transition: background 0.2s ease;
+  display: block;
+}
+
+#demo-files li a:hover,
+#demo-files li a:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
 }
 
 #console-log {

--- a/index.html
+++ b/index.html
@@ -30,29 +30,46 @@ Change Log:
   <style>
     #touch-controls {
       position: absolute;
-      bottom: 20px;
-      left: 20px;
+      bottom: clamp(16px, 4vw, 32px);
+      left: clamp(16px, 4vw, 32px);
       display: flex;
-      gap: 20px;
+      gap: 24px;
       z-index: 10;
+      background: rgba(0, 0, 0, 0.25);
+      padding: 12px 16px;
+      border-radius: 14px;
+      backdrop-filter: blur(6px);
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
     }
     #move-pad {
       display: grid;
-      grid-template-columns: 40px 40px 40px;
-      grid-template-rows: 40px 40px 40px;
-      gap: 5px;
+      grid-template-columns: 56px 56px 56px;
+      grid-template-rows: 56px 56px 56px;
+      gap: 8px;
     }
     #move-forward { grid-column: 2; grid-row: 1; }
     #move-left { grid-column: 1; grid-row: 2; }
     #move-right { grid-column: 3; grid-row: 2; }
     #move-back { grid-column: 2; grid-row: 3; }
-    #zoom-pad { display: flex; flex-direction: column; gap: 5px; }
+    #zoom-pad { display: flex; flex-direction: column; gap: 8px; justify-content: center; }
     #touch-controls button {
-      width: 40px;
-      height: 40px;
-      background: rgba(255, 255, 255, 0.5);
-      border: 1px solid #888;
-      border-radius: 4px;
+      width: 56px;
+      height: 56px;
+      background: rgba(255, 255, 255, 0.65);
+      border: none;
+      border-radius: 10px;
+      color: #001533;
+      font-size: 1.4rem;
+      font-weight: 600;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 6px 18px rgba(0, 0, 0, 0.25);
+      transition: transform 0.12s ease, background 0.15s ease;
+    }
+    #touch-controls button:active {
+      transform: translateY(2px);
+      background: rgba(255, 255, 255, 0.8);
     }
   </style>
   <script>

--- a/js/interaction.js
+++ b/js/interaction.js
@@ -18,12 +18,13 @@ export function initInteraction({ container, renderer, camera, meshes, apps }) {
     const data = apps[index];
     meshes.forEach((m, i) => {
       m.material.transparent = true;
+      const baseScale = (m.userData && m.userData.baseScale) || 1;
       if (i === index) {
-        m.scale.set(1.5, 1.5, 1.5);
+        m.scale.setScalar(baseScale * 1.35);
         m.material.opacity = 1;
       } else {
-        m.scale.set(1, 1, 1);
-        m.material.opacity = 0.25;
+        m.scale.setScalar(baseScale);
+        m.material.opacity = 0.35;
       }
     });
     infoTitle.textContent = data.name;
@@ -47,7 +48,8 @@ export function initInteraction({ container, renderer, camera, meshes, apps }) {
       infoBox.style.display = 'none';
     }, 1000);
     meshes.forEach(m => {
-      m.scale.set(1, 1, 1);
+      const baseScale = (m.userData && m.userData.baseScale) || 1;
+      m.scale.setScalar(baseScale);
       m.material.opacity = 1;
       m.material.transparent = false;
     });

--- a/js/script.js
+++ b/js/script.js
@@ -85,42 +85,38 @@ head.castShadow = true;
 character.add(body);
 character.add(head);
 character.scale.setScalar(0.7);
-character.position.set(0, 1.2, 2.8);
+character.position.set(-4, 1.2, 3.2);
+character.rotation.y = 0.35;
 scene.add(character);
 
-const radius = 4;
+const arcSpacing = 2.4;
+const depthOffset = 0.6;
+const depthCurve = 0.45;
+const arcCenter = (apps.length - 1) / 2;
+const focusPoint = new THREE.Vector3(0, 2, 0);
 apps.forEach((app, i) => {
-  const angle = (i / apps.length) * Math.PI * 2;
-  const x = Math.cos(angle) * radius;
-  const z = Math.sin(angle) * radius;
+  const offsetIndex = i - arcCenter;
+  const x = offsetIndex * arcSpacing;
+  const z = depthOffset + Math.abs(offsetIndex) * depthCurve;
   const geometry = i % 2 === 0
-    ? new THREE.IcosahedronGeometry(0.85)
-    : new THREE.TorusGeometry(0.65, 0.2, 16, 30);
+    ? new THREE.IcosahedronGeometry(0.95)
+    : new THREE.TorusGeometry(0.75, 0.22, 18, 32);
   const color = i % 2 === 0 ? 0xff6600 : 0x0096d6;
   const mesh = new THREE.Mesh(geometry, new THREE.MeshStandardMaterial({ color }));
   mesh.position.set(x, 1.7, z);
   mesh.castShadow = true;
   mesh.receiveShadow = true;
+  mesh.userData.baseScale = 1.1;
+  mesh.scale.setScalar(mesh.userData.baseScale);
+  mesh.userData.focusPoint = focusPoint.clone();
   scene.add(mesh);
   meshes.push(mesh);
-  const offsetX = x < 0 ? -20 : 20;
+  const offsetX = offsetIndex < 0 ? -26 : 26;
   addLabel(mesh, app.name, labelColor, -1, 'object-label', offsetX);
-  addLabel(mesh, app.short, labelColor, -1.5, 'object-info', offsetX);
+  addLabel(mesh, app.short, labelColor, -1.45, 'object-info', offsetX);
 });
 
 initInteraction({ container, renderer, camera, meshes, apps });
-
-function bindHold(btn, action) {
-  let interval;
-  btn.addEventListener('pointerdown', e => {
-    e.preventDefault();
-    action();
-    interval = setInterval(action, 100);
-  });
-  ['pointerup', 'pointerleave', 'touchend', 'touchcancel'].forEach(ev =>
-    btn.addEventListener(ev, () => clearInterval(interval))
-  );
-}
 
 function setupTouchControls() {
   const forwardBtn = document.getElementById('move-forward');
@@ -129,32 +125,162 @@ function setupTouchControls() {
   const rightBtn = document.getElementById('move-right');
   const zoomInBtn = document.getElementById('zoom-in');
   const zoomOutBtn = document.getElementById('zoom-out');
-  const moveStep = 0.2;
-  const zoomStep = 2;
-  bindHold(forwardBtn, () => {
-    camera.position.z -= moveStep;
-    camera.lookAt(0, 2, 0);
-  });
-  bindHold(backBtn, () => {
-    camera.position.z += moveStep;
-    camera.lookAt(0, 2, 0);
-  });
-  bindHold(leftBtn, () => {
-    camera.position.x -= moveStep;
-    camera.lookAt(0, 2, 0);
-  });
-  bindHold(rightBtn, () => {
-    camera.position.x += moveStep;
-    camera.lookAt(0, 2, 0);
-  });
-  bindHold(zoomInBtn, () => {
-    camera.fov = Math.max(20, camera.fov - zoomStep);
-    camera.updateProjectionMatrix();
-  });
-  bindHold(zoomOutBtn, () => {
-    camera.fov = Math.min(100, camera.fov + zoomStep);
-    camera.updateProjectionMatrix();
-  });
+  if (!forwardBtn || !backBtn || !leftBtn || !rightBtn || !zoomInBtn || !zoomOutBtn) {
+    return;
+  }
+
+  const pivot = focusPoint.clone();
+  const forwardVec = new THREE.Vector3();
+  const orbitOffset = new THREE.Vector3();
+  const pivotOffset = new THREE.Vector3();
+  const yAxis = new THREE.Vector3(0, 1, 0);
+  const state = {
+    forwardTarget: 0,
+    orbitTarget: 0,
+    forward: 0,
+    orbit: 0,
+    zoomDirectionTarget: 0,
+    zoomDirection: 0,
+    zoomTarget: camera.fov,
+    zoom: camera.fov
+  };
+  let animationActive = false;
+  let lastTime = performance.now();
+
+  function ensureAnimation() {
+    if (!animationActive) {
+      animationActive = true;
+      lastTime = performance.now();
+      requestAnimationFrame(step);
+    }
+  }
+
+  function applyCameraMotion(delta) {
+    const moveSpeed = 3.2;
+    const orbitSpeed = 1.3;
+    const zoomSpeed = 28;
+    state.forward = THREE.MathUtils.damp(state.forward, state.forwardTarget, 8, delta);
+    state.orbit = THREE.MathUtils.damp(state.orbit, state.orbitTarget, 8, delta);
+    state.zoomDirection = THREE.MathUtils.damp(state.zoomDirection, state.zoomDirectionTarget, 10, delta);
+    state.zoom = THREE.MathUtils.damp(state.zoom, state.zoomTarget, 12, delta);
+
+    const forwardDelta = state.forward * delta * moveSpeed;
+    if (Math.abs(forwardDelta) > 0.0001) {
+      camera.getWorldDirection(forwardVec);
+      forwardVec.y = 0;
+      if (forwardVec.lengthSq() > 0) {
+        forwardVec.normalize();
+        camera.position.addScaledVector(forwardVec, forwardDelta);
+      }
+    }
+
+    const orbitDelta = state.orbit * delta * orbitSpeed;
+    if (Math.abs(orbitDelta) > 0.0001) {
+      orbitOffset.copy(camera.position).sub(pivot);
+      orbitOffset.applyAxisAngle(yAxis, orbitDelta);
+      camera.position.copy(orbitOffset.add(pivot));
+    }
+
+    if (Math.abs(state.zoomDirection) > 0.0001) {
+      state.zoomTarget = THREE.MathUtils.clamp(
+        state.zoomTarget + state.zoomDirection * delta * zoomSpeed,
+        32,
+        85
+      );
+    }
+
+    if (Math.abs(camera.fov - state.zoom) > 0.0001) {
+      camera.fov = state.zoom;
+      camera.updateProjectionMatrix();
+    }
+
+    pivotOffset.copy(camera.position).sub(pivot);
+    const minDistance = 4.5;
+    const maxDistance = 14;
+    const currentDistance = pivotOffset.length();
+    if (currentDistance < minDistance || currentDistance > maxDistance) {
+      pivotOffset.setLength(THREE.MathUtils.clamp(currentDistance, minDistance, maxDistance));
+      camera.position.copy(pivotOffset.add(pivot));
+    }
+
+    camera.lookAt(pivot);
+  }
+
+  function step() {
+    const now = performance.now();
+    const delta = Math.min((now - lastTime) / 1000, 0.12);
+    lastTime = now;
+    applyCameraMotion(delta);
+
+    const isMoving =
+      Math.abs(state.forward - state.forwardTarget) > 0.001 ||
+      Math.abs(state.orbit - state.orbitTarget) > 0.001 ||
+      Math.abs(state.zoomDirection - state.zoomDirectionTarget) > 0.001 ||
+      Math.abs(camera.fov - state.zoomTarget) > 0.1 ||
+      Math.abs(state.forward) > 0.0005 ||
+      Math.abs(state.orbit) > 0.0005 ||
+      Math.abs(state.zoomDirection) > 0.0005;
+
+    if (isMoving) {
+      requestAnimationFrame(step);
+    } else {
+      animationActive = false;
+    }
+  }
+
+  function bindPress(button, start, end) {
+    if (!button) return;
+    const activePointers = new Set();
+    const onPointerDown = event => {
+      event.preventDefault();
+      activePointers.add(event.pointerId);
+      if (activePointers.size === 1 && start) {
+        start();
+      }
+      button.setPointerCapture?.(event.pointerId);
+    };
+    const onPointerUp = event => {
+      if (activePointers.has(event.pointerId)) {
+        activePointers.delete(event.pointerId);
+        if (activePointers.size === 0 && end) {
+          end();
+        }
+      }
+      button.releasePointerCapture?.(event.pointerId);
+    };
+    button.addEventListener('pointerdown', onPointerDown);
+    button.addEventListener('pointerup', onPointerUp);
+    button.addEventListener('pointerleave', onPointerUp);
+    button.addEventListener('pointercancel', onPointerUp);
+    button.addEventListener('lostpointercapture', onPointerUp);
+    button.addEventListener('contextmenu', e => e.preventDefault());
+  }
+
+  const setForwardTarget = value => {
+    if (state.forwardTarget !== value) {
+      state.forwardTarget = value;
+      ensureAnimation();
+    }
+  };
+  const setOrbitTarget = value => {
+    if (state.orbitTarget !== value) {
+      state.orbitTarget = value;
+      ensureAnimation();
+    }
+  };
+  const setZoomDirection = value => {
+    if (state.zoomDirectionTarget !== value) {
+      state.zoomDirectionTarget = value;
+      ensureAnimation();
+    }
+  };
+
+  bindPress(forwardBtn, () => setForwardTarget(1), () => setForwardTarget(0));
+  bindPress(backBtn, () => setForwardTarget(-1), () => setForwardTarget(0));
+  bindPress(leftBtn, () => setOrbitTarget(1), () => setOrbitTarget(0));
+  bindPress(rightBtn, () => setOrbitTarget(-1), () => setOrbitTarget(0));
+  bindPress(zoomInBtn, () => setZoomDirection(-1), () => setZoomDirection(0));
+  bindPress(zoomOutBtn, () => setZoomDirection(1), () => setZoomDirection(0));
 }
 
 setupTouchControls();


### PR DESCRIPTION
## Summary
- remove stray scrollbars by forcing the page layout to occupy the viewport and keeping the scene canvas inside its bounds
- move the demo list to a styled panel on the left across all themes and polish the touch control pad appearance
- reorganize demo meshes into an even arc and add smooth camera movement and zoom easing for the on-screen arrows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca57056c0c832aad187a71f6c8907c