### PR TITLE
Use title case for Terrain app name

### DIFF
--- a/apps/app3/index.html
+++ b/apps/app3/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>TERRAIN</title>
+  <title>Terrain</title>
   <style>
     html, body { margin: 0; height: 100%; overflow: hidden; }
     canvas { display: block; }

--- a/data/index.json
+++ b/data/index.json
@@ -7,7 +7,7 @@
       "long": "This is the first demo showcasing features."
     },
     {
-      "name": "TERRAIN",
+      "name": "Terrain",
       "file": "apps/app3/index.html",
       "short": "lorem ipsum doloret sit amet",
       "long": "This is the third demo showcasing features."


### PR DESCRIPTION
## Summary
- update the Terrain app metadata to use title casing in the directory listing
- adjust the Terrain demo HTML title to match the new casing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d561909ae4832aa2d9c0845d6b5567