### PR TITLE
Bump project version to 1.9.1

### DIFF
--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -110,10 +110,10 @@
   ],
   "status": "Ready.",
   "welcome": {
-    "title": "WebGUI 0.1.1",
+    "title": "WebGUI 1.9.1",
     "lines": [
       "Welcome to WebGUI - Web browser based windows GUI",
-      "Version 0.1.1",
+      "Version 1.9.1",
       "(c) 2025 CyborgsDream"
     ],
     "button": "OK"
@@ -189,7 +189,7 @@
   "windows": {
     "system-info": {
       "title": "System Information",
-      "content": "<h2>WebGUI Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>WebGUI 0.1.1</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Power Without the Price</div></div>",
+      "content": "<h2>WebGUI Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>WebGUI 1.9.1</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Power Without the Price</div></div>",
       "width": 320,
       "height": 300
     },
@@ -201,7 +201,7 @@
     },
     "text-editor": {
         "title": "Text Editor",
-        "content": "<div class=\"text-editor\" style=\"display:flex;flex-direction:column;height:100%\"><div style=\"text-align:right;margin-bottom:5px;\"><button id=\"text-editor-export\" style=\"font-size:16px;\">Export PDF</button></div><textarea id=\"text-editor-area\" style=\"flex:1;background:#fff;border:1px solid #aaa;padding:5px;font-family:monospace;font-size:18px;\">Welcome to WebGUI 0.1.1!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea></div>",
+        "content": "<div class=\"text-editor\" style=\"display:flex;flex-direction:column;height:100%\"><div style=\"text-align:right;margin-bottom:5px;\"><button id=\"text-editor-export\" style=\"font-size:16px;\">Export PDF</button></div><textarea id=\"text-editor-area\" style=\"flex:1;background:#fff;border:1px solid #aaa;padding:5px;font-family:monospace;font-size:18px;\">Welcome to WebGUI 1.9.1!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea></div>",
         "width": 500,
         "height": 350
       },

--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -1,5 +1,5 @@
 <!--
- * @version   v0.0.19
+ * @version   v1.9.1
  * @codename  "ZoomWin"
  * @author    Prof. Adrian Zephyr
  * @date      2025-08-12
@@ -12,7 +12,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>WebGUI 0.1.1</title>
+    <title>WebGUI 1.9.1</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=VT323&display=swap">
     <style>
         * {

--- a/apps/universe/index.html
+++ b/apps/universe/index.html
@@ -1,6 +1,6 @@
 <!--
 /**
- * @version   v2.0.0
+ * @version   v1.9.1
  * @codename  "CELESTIAL_TERRAIN_HYPERLUMINAL"
  * @author    Codex Prodigy
  * @date      2025-08-13
@@ -40,20 +40,20 @@
   </style>
 </head>
 <body>
-  <div id="container" data-app-version="v2.0.0">
+  <div id="container" data-app-version="v1.9.1">
     <div id="fps"></div>
     <div class="hud">
       <div><kbd>G</kbd> GRB • <kbd>N</kbd> Nebula • <kbd>A</kbd> AutoCam • <kbd>↑↓←→</kbd> Manual • <kbd>R</kbd> Reset</div>
     </div>
     <div id="overlay-error"></div>
-    <div id="note">v2.0.0 • Booting…</div>
+    <div id="note">v1.9.1 • Booting…</div>
     <div id="placeholder">Loading 3D scene…</div>
   </div>
   <noscript>This demo requires JavaScript enabled.</noscript>
 
   <script>
   // ===== Version =====
-  const APP_VERSION  = 'v2.0.0';
+  const APP_VERSION  = 'v1.9.1';
   const APP_CODENAME = 'CELESTIAL_TERRAIN_HYPERLUMINAL';
   window.APP_VERSION = APP_VERSION; window.APP_CODENAME = APP_CODENAME;
 

--- a/css/style-futuristic.css
+++ b/css/style-futuristic.css
@@ -1,4 +1,4 @@
-/* Version: 0.1.1 */
+/* Version: 1.9.1 */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {

--- a/css/style-light.css
+++ b/css/style-light.css
@@ -1,4 +1,4 @@
-/* Version: 0.1.1 */
+/* Version: 1.9.1 */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {

--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/* Version: 0.1.1 */
+/* Version: 1.9.1 */
 /* Codename: Celestia */
 /* Basic responsive CSS */
 * {

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--
-Version: 0.1.1
+Version: 1.9.1
 Codename: Celestia
 Change Log:
  - Initial responsive boilerplate
@@ -13,7 +13,7 @@ Change Log:
 - Switched object labels to <h3> elements
  - Made info text white for visibility
 - Removed console log background and limited visibility to 3 seconds
- - Bumped version to 0.1.1
+ - Bumped version to 1.9.1
  - Enabled dynamic 16:9 scaling for larger screens
  - Reduced DEMOS text wave range and limited movement to Z axis
 - Raised demo objects and enabled inter-object shadows
@@ -93,7 +93,7 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
-      <div id="version-number">v0.1.1</div>
+      <div id="version-number">v1.9.1</div>
       <div id="console-log"></div>
       <div id="app-info">
         <span id="close-info" class="close-icon" aria-label="Close">&times;</span>

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,4 @@
-// Version: 0.1.1
+// Version: 1.9.1
 // Codename: Celestia
 // Basic THREE.js example with multiple objects
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';


### PR DESCRIPTION
## Summary
- update the root DEMOS page version metadata and overlay to 1.9.1
- synchronize CSS, JavaScript, and WebGUI app assets to report version 1.9.1
- align the Universe demo's version annotations and boot note with 1.9.1

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d57cdb5d90832a8f21eca61b9919f9