### PR TITLE
Add FPS counter and console overlay to terrain demo

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -4,7 +4,14 @@
   <meta charset="utf-8">
   <title>Terrain</title>
   <style>
-    html, body { margin: 0; height: 100%; overflow: hidden; }
+    html, body {
+      margin: 0;
+      height: 100%;
+      overflow: hidden;
+      background: #000;
+      color: #fff;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    }
     canvas { display: block; }
     #loader {
       position: fixed;
@@ -20,16 +27,107 @@
       font-family: sans-serif;
       font-size: 2em;
     }
+    #fps {
+      position: fixed;
+      top: 8px;
+      left: 8px;
+      z-index: 40;
+      pointer-events: none;
+    }
   </style>
 </head>
 <body>
+<div id="fps"></div>
 <div id="loader">Loading <span id="progress">0%</span></div>
 <script type="module">
 import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+import { initConsoleLogs } from '../../shared/consolelogs.js';
+
+initConsoleLogs({ removeAfter: null });
+
+class MiniStats {
+  constructor(){
+    this.dom = document.createElement('div');
+    this.dom.style.cssText = 'background:rgba(0,0,0,.6);padding:4px 6px;font:12px/1.2 monospace;';
+    this.dom.style.pointerEvents = 'none';
+    this.label = document.createElement('div');
+    this.dom.appendChild(this.label);
+    this._smoothing = 0.9;
+    this._fps = 0;
+    this._valid = false;
+    this.begin();
+  }
+  begin(){ this._tick = performance.now(); }
+  end(){
+    const now = performance.now();
+    const dt = now - this._tick;
+    const inst = 1000 / Math.max(dt, 0.0001);
+    this._fps = this._valid ? (this._smoothing * this._fps + (1 - this._smoothing) * inst) : inst;
+    this._valid = true;
+    this.label.textContent = `FPS: ${this._fps.toFixed(1)} | ms: ${dt.toFixed(2)}`;
+  }
+  showPanel() {}
+}
+
+function loadScript(url, timeoutMs = 9000) {
+  return new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    const t = setTimeout(() => {
+      s.onload = s.onerror = null;
+      reject(new Error('Timeout loading: ' + url));
+    }, timeoutMs);
+    s.src = url;
+    s.async = true;
+    s.defer = true;
+    s.crossOrigin = 'anonymous';
+    s.referrerPolicy = 'no-referrer';
+    s.onload = () => { clearTimeout(t); resolve(url); };
+    s.onerror = () => {
+      clearTimeout(t);
+      reject(new Error('Failed to load: ' + url));
+    };
+    document.head.appendChild(s);
+  });
+}
+
+async function loadFirstAvailable(urls) {
+  let lastErr;
+  for (const url of urls) {
+    try {
+      await loadScript(url);
+      return url;
+    } catch (err) {
+      lastErr = err;
+      console.warn(err.message);
+    }
+  }
+  throw lastErr || new Error('All URLs failed: ' + urls.join(', '));
+}
 
 const loaderEl = document.getElementById('loader');
 const progressEl = document.getElementById('progress');
 function setProgress(p){ progressEl.textContent = Math.round(p) + '%'; }
+
+const fpsHolder = document.getElementById('fps');
+let stats;
+try {
+  const statsUrl = await loadFirstAvailable([
+    'https://unpkg.com/stats.js@0.17.0/build/stats.min.js',
+    'https://cdn.jsdelivr.net/npm/stats.js@0.17.0/build/stats.min.js',
+    'https://cdnjs.cloudflare.com/ajax/libs/stats.js/r17/Stats.min.js'
+  ]);
+  console.log('Stats loaded from:', statsUrl);
+  const StatsCtor = (typeof window !== 'undefined' && window.Stats) ? window.Stats : MiniStats;
+  stats = new StatsCtor();
+  if (stats.showPanel) stats.showPanel(0);
+} catch (err) {
+  console.warn('Stats unavailable, using MiniStats. Cause:', err.message);
+  stats = new MiniStats();
+}
+if (stats?.dom) {
+  stats.dom.style.pointerEvents = 'none';
+  fpsHolder.appendChild(stats.dom);
+}
 
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setSize(window.innerWidth, window.innerHeight);
@@ -149,6 +247,7 @@ async function generateBlocks(count) {
   }
   setProgress(100);
   loaderEl.remove();
+  console.log(`Terrain populated with ${count} blocks.`);
 }
 
 function updateControls(dt){
@@ -186,13 +285,17 @@ function animate(){
   const now = performance.now();
   const dt = Math.min(0.05, (now - last) / 1000);
   last = now;
+  if (stats?.begin) stats.begin();
   updateControls(dt);
   updateTerrainFollow();
   renderer.render(scene, camera);
+  if (stats?.end) stats.end();
   requestAnimationFrame(animate);
 }
 
+console.log('Terrain initialising...');
 await generateBlocks(1000);
+console.log('Terrain ready.');
 animate();
 
 window.addEventListener('resize', () => {

--- a/data/index.json
+++ b/data/index.json
@@ -8,7 +8,7 @@
     },
     {
       "name": "Terrain",
-      "file": "apps/app3/index.html",
+      "file": "apps/terrain/index.html",
       "short": "lorem ipsum doloret sit amet",
       "long": "This is the third demo showcasing features."
     },


### PR DESCRIPTION
## Summary
- rename the terrain demo folder to apps/terrain and update its data catalog entry
- integrate the Stats.js FPS counter (with MiniStats fallback) and a console log overlay into the terrain experience
- surface helpful lifecycle logging while generating terrain content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d65f59eb7c832a8e73dab45a51ca89