### PR TITLE
Update Orbit OS branding and frame handles

### DIFF
--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -19,7 +19,7 @@
           "label": "Format Disk"
         },
         {
-          "label": "Exit WebGUI"
+          "label": "Exit Orbit OS v 0.1.0"
         }
       ]
     },
@@ -82,7 +82,7 @@
           "type": "notes"
         },
         {
-          "label": "DocuMonster",
+          "label": "Docu Monster Studio Pro",
           "type": "document-editor"
         }
       ]
@@ -114,10 +114,10 @@
   ],
   "status": "Ready.",
   "welcome": {
-    "title": "WebGUI 1.9.1",
+    "title": "Orbit OS v 0.1.0",
     "lines": [
-      "Welcome to WebGUI - Web browser based windows GUI",
-      "Version 1.9.1",
+      "Welcome to Orbit OS v 0.1.0 — browser-based creative desktop",
+      "Powered by Docu Monster Studio Pro 0.1.0",
       "(c) 2025 CyborgsDream"
     ],
     "button": "OK"
@@ -142,7 +142,7 @@
       {
         "type": "document-editor",
         "emoji": "📄",
-        "label": "DocuMonster"
+        "label": "Docu Monster Studio Pro"
       },
       {
         "type": "calculator",
@@ -198,19 +198,19 @@
   "windows": {
     "system-info": {
       "title": "System Information",
-      "content": "<h2>WebGUI Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>WebGUI 1.9.1</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Power Without the Price</div></div>",
+      "content": "<h2>Orbit OS v 0.1.0 Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>Orbit OS v 0.1.0</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Creative Control</div></div>",
       "width": 320,
       "height": 300
     },
     "terminal": {
       "title": "CLI",
-      "content": "<div class=\"terminal\"><div class=\"terminal-line\">WebGUI CLI</div><div class=\"terminal-line\">(c) 2025 CyborgsDream</div><div class=\"terminal-line\">WebGUI started.</div><div class=\"terminal-line\">System date: {DATE}</div><div class=\"terminal-line\">System time: {TIME}</div><div class=\"terminal-line\"><br></div><div class=\"terminal-line\"><span class=\"prompt\">1&gt;</span> <span class=\"cursor\">█</span></div></div>",
+      "content": "<div class=\"terminal\"><div class=\"terminal-line\">Orbit OS v 0.1.0 CLI</div><div class=\"terminal-line\">(c) 2025 CyborgsDream</div><div class=\"terminal-line\">Orbit OS v 0.1.0 started.</div><div class=\"terminal-line\">System date: {DATE}</div><div class=\"terminal-line\">System time: {TIME}</div><div class=\"terminal-line\"><br></div><div class=\"terminal-line\"><span class=\"prompt\">1&gt;</span> <span class=\"cursor\">█</span></div></div>",
       "width": 450,
       "height": 250
     },
     "text-editor": {
         "title": "Text Editor",
-        "content": "<div class=\"text-editor\" style=\"display:flex;flex-direction:column;height:100%\"><div style=\"text-align:right;margin-bottom:5px;\"><button id=\"text-editor-export\" style=\"font-size:16px;\">Export PDF</button></div><textarea id=\"text-editor-area\" style=\"flex:1;background:#fff;border:1px solid #aaa;padding:5px;font-family:monospace;font-size:18px;\">Welcome to WebGUI 1.9.1!\n\nThe icon issue has been fixed!\n• All desktop icons are now fully functional\n• Click any icon to open an application\n• The wallpaper no longer blocks clicks\n\nTry clicking on any icon to open its application.\n\nWebGUI continues to push the boundaries of personal computing!</textarea></div>",
+        "content": "<div class=\"text-editor\" style=\"display:flex;flex-direction:column;height:100%\"><div style=\"text-align:right;margin-bottom:5px;\"><button id=\"text-editor-export\" style=\"font-size:16px;\">Export PDF</button></div><textarea id=\"text-editor-area\" style=\"flex:1;background:#fff;border:1px solid #aaa;padding:5px;font-family:monospace;font-size:18px;\">Welcome to Orbit OS v 0.1.0!\n\nThe workspace has been retuned for Docu Monster Studio Pro 0.1.0.\n• All desktop icons are ready for Orbit OS v 0.1.0 apps\n• Click any icon to open its application\n• Wallpaper layering stays click-through\n\nLaunch Docu Monster Studio Pro 0.1.0 to design spreads and export PDFs straight from Orbit OS v 0.1.0.</textarea></div>",
         "width": 500,
         "height": 350
       },
@@ -257,7 +257,7 @@
       "height": 450
     },
     "document-editor": {
-      "title": "DocuMonster A4 Studio",
+      "title": "Docu Monster Studio Pro A4",
       "content": "<iframe src=\"documonster.html\" style=\"width:100%;height:100%;border:none;background:#c0c0c0;\"></iframe>",
       "width": 1280,
       "height": 900

--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -12,7 +12,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>WebGUI 1.9.1</title>
+    <title>Orbit OS v 0.1.0</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=VT323&display=swap">
     <style>
         * {
@@ -610,19 +610,6 @@
         <div class="task-bar" id="task-bar"></div>
         <div class="taskbar-menu" id="taskbar-menu" style="display:none;"></div>
         
-        <!-- System name dialog -->
-        <div class="dialog" id="system-name-dialog" style="display:none;">
-            <div class="window-header">
-                <div class="window-title">System Name</div>
-            </div>
-            <div class="dialog-content">
-                <input id="system-name-input" type="text" style="width:80%;" placeholder="Enter system name">
-                <div class="dialog-buttons">
-                    <div class="dialog-btn" id="system-name-ok">OK</div>
-                </div>
-            </div>
-        </div>
-
         <!-- Theme selection dialog -->
         <div class="dialog" id="theme-dialog" style="display:none;">
             <div class="window-header">
@@ -1051,23 +1038,6 @@
             }
         }
         
-        
-        // Dialog functions
-        function askSystemName() {
-            return new Promise(resolve => {
-                const dialog = document.getElementById('system-name-dialog');
-                dialog.style.display = 'block';
-                document.getElementById('system-name-ok').onclick = () => {
-                    const name = document.getElementById('system-name-input').value.trim();
-                    if (name) {
-                        localStorage.setItem('systemName', name);
-                    }
-                    closeDialog('system-name-dialog');
-                    resolve(name);
-                };
-            });
-        }
-
         function selectThemeDialog() {
             return new Promise(resolve => {
                 const dialog = document.getElementById('theme-dialog');
@@ -1090,7 +1060,6 @@
         // Initialize everything
         async function init() {
             setTheme('retro');
-            await askSystemName();
             await selectThemeDialog();
             const res = await fetch('app-data/app1.json');
             appData = await res.json();

--- a/apps/app1/app-js/documonster.js
+++ b/apps/app1/app-js/documonster.js
@@ -1,2 +1,2 @@
-// Launch DocuMonster document studio inside a window iframe
+// Launch Docu Monster Studio Pro document studio inside a window iframe
 WinAPI.createWindow('document-editor');

--- a/apps/app1/documonster.html
+++ b/apps/app1/documonster.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta http-equiv="Content-Language" content="en" />
-<title>DocuMonster — ProtoDesk Orbit v0.9.0</title>
+<title>Docu Monster Studio Pro — Orbit OS v 0.1.0</title>
 <style>
   /* ===== Base ===== */
   *,*::before,*::after{ box-sizing:border-box; }
@@ -182,10 +182,11 @@
   .frame-image{ flex:1 1 auto; background:repeating-linear-gradient(135deg,#dde7ef,#dde7ef 12px,#c7d6e5 12px,#c7d6e5 24px); display:flex; align-items:center; justify-content:center; color:#344860; font:11px var(--font-ui); text-align:center; padding:4mm; }
   .frame-image[data-src]{ background-size:cover; background-position:center; color:transparent; text-indent:-9999px; }
   .frame figcaption{ font:11px var(--font-ui); color:#333; padding:2mm 3mm 3mm; }
-  .frame .resize-handle{ position:absolute; width:10px; height:10px; background:#000080; border:1px solid #fff; }
+  .frame .resize-handle{ position:absolute; width:10px; height:10px; background:#000080; border:1px solid #fff; display:none; }
   .frame .resize-handle.se{ right:-5px; bottom:-5px; cursor:se-resize; }
   .frame .resize-handle.e{ right:-5px; top:50%; transform:translateY(-50%); cursor:e-resize; }
   .frame .resize-handle.s{ bottom:-5px; left:50%; transform:translateX(-50%); cursor:s-resize; }
+  .frame.selected .resize-handle{ display:block; }
   .quote{ font-size:14px; line-height:1.3; }
   .attribution{ font:11px var(--font-ui); text-transform:uppercase; letter-spacing:0.08em; }
   .callout{ font:12px var(--font-ui); font-weight:bold; }
@@ -211,6 +212,7 @@
     :root{ --m-top:12mm; --m-bot:12mm; --m-in:12mm; --m-out:12mm; }
     body.pdf-mirror .sheet.even{ --m-in:20mm; --m-out:14mm; }
     *{ -webkit-print-color-adjust:exact; print-color-adjust:exact; }
+    .frame .resize-handle{ display:none !important; }
   }
 </style>
 <body>
@@ -309,7 +311,7 @@
     <div class="spacer"></div>
     <div class="win-group">
       <span class="win-stat" id="status">Ready.</span>
-      <span class="win-stat" id="ver">ProtoDesk Orbit v0.9.0 • DocuMonster 0.8.0</span>
+      <span class="win-stat" id="ver">Orbit OS v 0.1.0 • Docu Monster Studio Pro 0.1.0</span>
     </div>
   </div>
 
@@ -333,7 +335,7 @@
 (function(){
   'use strict';
   const pxPerMm = 96/25.4;
-  const STORAGE_KEY = 'documonster-autosave-v0-9';
+  const STORAGE_KEY = 'documonster-studiopro-autosave-v0-1';
   const pagesEl = document.getElementById('pages');
   const releaseCardEl = document.getElementById('releaseCard');
   const curEl = document.getElementById('cur');
@@ -387,47 +389,48 @@
 
   function defaultDocument(){
     return {
-      version:'0.9.0',
-      docVersion:'0.8.0',
-      codename:'ProtoDesk Orbit',
+      version:'0.1.0',
+      docVersion:'0.1.0',
+      codename:'Orbit OS',
+      docName:'Docu Monster Studio Pro',
       releaseNotes:[
-        'Windows 3.11 inspired menubar with File/Export/Edit commands.',
-        'Dynamic columns, draggable overlay frames, and floating wraps.',
-        'Metric + imperial rulers for precision layout in the browser.',
-        'Autosave, JSON import/export, and PDF bleed/trim exports.'
+        'Orbit OS v 0.1.0 desktop shell refreshed with renamed menus and inspector tools.',
+        'Docu Monster Studio Pro 0.1.0 editing engine with multi-column layouts and floating frames.',
+        'Guides, rulers, and print marks aligned with Docu Monster Studio Pro terminology.',
+        'Docu Monster Studio Pro PDF exports with bleed and trim presets ready for press.'
       ],
       pages:[
         {
-          title:'PROTO DESK LAUNCH DOSSIER',
-          subtitle:'DocuMonster Studio Editor 0.8.0',
-          deck:'A Windows 3.11 inspired layout lab for the browser-native creative desktop.',
+          title:'ORBIT OS LAUNCH DOSSIER',
+          subtitle:'Docu Monster Studio Pro 0.1.0',
+          deck:'Orbit OS v 0.1.0 introduces Docu Monster Studio Pro, a desktop publishing lab for the browser.',
           elements:[
             {
               type:'columns', columns:2,
-              html:'<p>DocuMonster enters a quasi-operating-system era with ProtoDesk Orbit. This release introduces a polished menubar, autosave, and a true layout inspector that keeps your spreads fluid while remaining production ready.</p>'+
-                   '<p>Use the new Edit menu to mix single, double, or triple column grids inside a single spread. Add text or image frames, then choose whether they float alongside the story or overlay for poster-style compositions.</p>'+
-                   '<p>Versioning is now meaningful: the core editor is DocuMonster 0.8.0, bundled inside ProtoDesk Orbit v0.9.0—the codename for our browser-based creative desktop.</p>'+
-                   '<p>Guides, crop marks, and proofing toggles remain one click away. Save layouts locally or export press-ready PDFs straight from the Export menu.</p>'
+              html:'<p>Docu Monster Studio Pro debuts alongside Orbit OS v 0.1.0. The refreshed shell keeps the retro desktop look while focusing entirely on print production.</p>'+
+                   '<p>Swap between one, two, or three column grids from the Edit menu. Add text or image frames, set them to overlay or float, and fine-tune them with the inspector.</p>'+
+                   '<p>All terminology now aligns with Orbit OS and Docu Monster Studio Pro, making it clear which layer handles the interface and which powers layout.</p>'+
+                   '<p>Guides, crop marks, and colour bars are still a click away, so exporting from Docu Monster Studio Pro feels just like working in a print studio.</p>'
             },
             {
               type:'columns', columns:1,
               html:'<h2 class="span-all">Release Highlights</h2>'+
-                   '<ul class="bullet"><li>Persistent rulers in centimetres and inches for accurate placement.</li>'+
-                   '<li>Frame inspector for millimetre-perfect positioning.</li>'+
-                   '<li>Autosave with local storage plus JSON import/export.</li>'+
-                   '<li>Mirrored gutter toggles, bleed proofing, and Ugra/Fogra colour bars.</li></ul>'
+                   '<ul class="bullet"><li>Persistent centimetre and inch rulers for exact placement.</li>'+
+                   '<li>Frame inspector with millimetre precision controls.</li>'+
+                   '<li>Autosave with local storage plus JSON import and export.</li>'+
+                   '<li>Mirrored gutter toggles, bleed proofing, and Docu Monster Studio Pro colour bars.</li></ul>'
             },
             {
               type:'frame', frameType:'text', mode:'overlay', x:118, y:58, width:62, height:40,
-              content:'<p class="quote">“Design for print, proof in the browser, and ship without leaving ProtoDesk.”</p><p class="attribution">— DocuMonster Team</p>',
+              content:'<p class="quote">“Design for print, proof in the browser, and ship straight from Docu Monster Studio Pro.”</p><p class="attribution">— Orbit OS Team</p>',
               caption:''
             },
             {
               type:'frame', frameType:'image', mode:'float-right', x:110, y:120, width:70, height:50,
-              src:'', caption:'ProtoDesk shells the editor with a familiar Windows 3.11 style surface.'
+              src:'', caption:'Orbit OS wraps the editor with a familiar desktop-style workspace.'
             }
           ],
-          footerLeft:'DocuMonster ProtoDesk Orbit',
+          footerLeft:'Docu Monster Studio Pro • Orbit OS',
           footerRight:'Page {{page}} / {{total}} — Build {{version}}'
         },
         {
@@ -437,16 +440,16 @@
           elements:[
             {
               type:'columns', columns:3,
-              html:'<p>Switch between one, two, and three column sets inside the same spread. Each block remains editable—type directly into place and DocuMonster will keep track for autosave.</p>'+
+              html:'<p>Switch between one, two, and three column sets inside the same spread. Each block remains editable—type directly into place and Docu Monster Studio Pro keeps autosave running.</p>'+
                    '<p>Frame wrap controls let imagery ride alongside the story or float freely for poster art. Overlay frames honour millimetre coordinates; floats behave like magazine callouts.</p>'+
-                   '<p>Columns are contenteditable, so you can prototype copy or import drafted HTML snippets without leaving ProtoDesk.</p>'
+                   '<p>Columns are contenteditable, so you can prototype copy or import drafted HTML snippets without leaving Orbit OS.</p>'
             },
             {
               type:'columns', columns:2,
               html:'<h3 class="span-all">Workflow Tips</h3>'+
-                   '<p>Mix floats with overlay quotes for striking emphasis. Use the inspector to dial in the exact millimetre offsets while the rulers confirm alignment.</p>'+
+                   '<p>Mix floats with overlay quotes for emphasis. Use the inspector to dial in millimetre offsets while the rulers confirm alignment.</p>'+
                    '<p>Activate mirrored gutters when you are prepping signatures, then disable them for single-sided reports.</p>'+
-                   '<p>Autosave keeps your progress safe between sessions—reload later with the File → Load Autosave command.</p>'
+                   '<p>Autosave keeps progress safe between sessions—reload later with File → Load Autosave.</p>'
             },
             {
               type:'frame', frameType:'text', mode:'float-left', x:32, y:70, width:55, height:45,
@@ -459,7 +462,7 @@
             }
           ],
           footerLeft:'Workshop Series',
-          footerRight:'DocuMonster {{version}} • Page {{page}}'
+          footerRight:'Docu Monster Studio Pro {{version}} • Page {{page}}'
         },
         {
           title:'EXPORT & DELIVERY',
@@ -474,32 +477,32 @@
             {
               type:'columns', columns:1,
               html:'<p>Use Save As to download a JSON snapshot of this publication. Share with collaborators or re-import to continue editing. Autosave keeps a local copy even if you forget.</p>'+
-                   '<p>The rulers and inspector stay active while printing, so you can verify alignment before hitting Export.</p>'
+                   '<p>The rulers and inspector stay active while printing, so you can verify alignment before exporting from Docu Monster Studio Pro.</p>'
             },
             {
               type:'frame', frameType:'text', mode:'block', x:40, y:120, width:100, height:35,
-              content:'<p class="note">ProtoDesk Orbit surfaces system status in the toolbar. Watch the autosave indicator whenever you make quick adjustments.</p>',
+              content:'<p class="note">Orbit OS surfaces system status in the toolbar. Watch the autosave indicator whenever you make adjustments.</p>',
               caption:''
             }
           ],
           footerLeft:'Production Stack',
-          footerRight:'ProtoDesk Orbit — Page {{page}}/{{total}}'
+          footerRight:'Orbit OS — Page {{page}}/{{total}}'
         },
         {
           title:'SYSTEM MANIFEST',
-          subtitle:'Browser-based Windows-like studio',
-          deck:'The ProtoDesk initiative blurs the line between OS shell and creative suite.',
+          subtitle:'Browser-based studio platform',
+          deck:'Orbit OS frames the creative suite powered by Docu Monster Studio Pro.',
           elements:[
             {
               type:'columns', columns:2,
-              html:'<p>DocuMonster now ships with ProtoDesk Orbit, our browser-first desktop metaphor. The menubar mirrors Ami Pro on Windows 3.11, while the editing core stays modern and responsive.</p>'+
-                   '<p>This manifest tracks everything bundled in v0.9.0: rulers, menu commands, frame inspector, autosave, and more. Use it as a base template for your own newsroom workflows.</p>'
+              html:'<p>Docu Monster Studio Pro now ships with Orbit OS v 0.1.0, our browser-first desktop metaphor. The menubar nods to classic environments while the editor remains fast and modern.</p>'+
+                   '<p>This manifest tracks everything bundled in v0.1.0: rulers, menu commands, the frame inspector, autosave, and more. Use it as a base template for newsroom workflows.</p>'
             },
             {
               type:'columns', columns:2,
               html:'<h3 class="span-all">Included Modules</h3>'+
-                   '<ul class="bullet"><li>DocuMonster Editor 0.8.0 (column engine, frames, PDF export).</li>'+
-                   '<li>ProtoDesk shell v0.9.0 (menubar, status HUD, OS release card).</li>'+
+                   '<ul class="bullet"><li>Docu Monster Studio Pro 0.1.0 (column engine, frames, PDF export).</li>'+
+                   '<li>Orbit OS shell v 0.1.0 (menubar, status HUD, OS release card).</li>'+
                    '<li>Colour labs with Standard &amp; Ugra/Fogra presets.</li>'+
                    '<li>Layout workshop library with editable spreads.</li></ul>'
             },
@@ -508,8 +511,8 @@
               src:'', caption:'Frames can be positioned freely or floated for magazine style wraps.'
             }
           ],
-          footerLeft:'ProtoDesk Release Card',
-          footerRight:'{{codename}} v{{version}} — Page {{page}}'
+          footerLeft:'Orbit OS Release Card',
+          footerRight:'{{codename}} v {{version}} — Page {{page}}'
         }
       ]
     };
@@ -521,6 +524,7 @@
     doc.version = doc.version || base.version;
     doc.docVersion = doc.docVersion || base.docVersion;
     doc.codename = doc.codename || base.codename;
+    doc.docName = typeof doc.docName === 'string' && doc.docName.trim() ? doc.docName : base.docName;
     doc.releaseNotes = Array.isArray(doc.releaseNotes) && doc.releaseNotes.length ? doc.releaseNotes : base.releaseNotes.slice();
     doc.pages = Array.isArray(doc.pages) && doc.pages.length ? doc.pages.map(normalizePage) : base.pages.slice().map(normalizePage);
     return doc;
@@ -532,7 +536,7 @@
       subtitle:'',
       deck:'',
       elements:[],
-      footerLeft:'DocuMonster',
+      footerLeft:'Docu Monster Studio Pro',
       footerRight:'Page {{page}}'
     }, page || {});
     p.elements = Array.isArray(p.elements) ? p.elements.map(normalizeElement) : [];
@@ -606,14 +610,14 @@
   }
 
   function updateVersionInfo(){
-    versionEl.textContent = docModel.codename+' v'+docModel.version+' • DocuMonster '+docModel.docVersion;
-    document.title = 'DocuMonster — '+docModel.codename+' v'+docModel.version;
+    versionEl.textContent = docModel.codename+' v '+docModel.version+' • '+docModel.docName+' '+docModel.docVersion;
+    document.title = 'Docu Monster Studio Pro — '+docModel.codename+' v '+docModel.version;
   }
 
   function renderReleaseCard(){
     const notes = (docModel.releaseNotes || []).map(note=>'<li>'+note+'</li>').join('');
-    releaseCardEl.innerHTML = '<h2>'+docModel.codename+' v'+docModel.version+'</h2>'+
-      '<p>DocuMonster Editor '+docModel.docVersion+' • ProtoDesk Orbit environment.</p>'+
+    releaseCardEl.innerHTML = '<h2>'+docModel.codename+' v '+docModel.version+'</h2>'+
+      '<p>'+docModel.docName+' '+docModel.docVersion+' • '+docModel.codename+' v '+docModel.version+'</p>'+
       '<ul>'+notes+'</ul>';
   }
 
@@ -637,7 +641,7 @@
     marks.appendChild(bar);
     const info = document.createElement('div');
     info.className = 'info';
-    info.textContent = docModel.codename+' v'+docModel.version+' — page '+(idx+1)+'/'+getTotalPages();
+    info.textContent = docModel.codename+' v '+docModel.version+' — page '+(idx+1)+'/'+getTotalPages();
     marks.appendChild(info);
     ['tl','tr','bl','br'].forEach(pos=>{
       const r = document.createElement('div');
@@ -1221,7 +1225,7 @@
   }
 
   function addPage(afterIndex){
-    const base = { title:'Untitled Spread', subtitle:'', deck:'', elements:[{ type:'columns', columns:1, html:'<p>Start typing…</p>' }], footerLeft:'DocuMonster ProtoDesk', footerRight:'Page {{page}} / {{total}}' };
+    const base = { title:'Untitled Spread', subtitle:'', deck:'', elements:[{ type:'columns', columns:1, html:'<p>Start typing…</p>' }], footerLeft:'Docu Monster Studio Pro • Orbit OS', footerRight:'Page {{page}} / {{total}}' };
     docModel.pages.splice(afterIndex+1, 0, base);
     markDirty();
     renderDocument();

--- a/data/index.json
+++ b/data/index.json
@@ -1,7 +1,7 @@
 {
   "apps": [
     {
-      "name": "WebGUI",
+      "name": "Orbit OS v 0.1.0",
       "file": "apps/app1/app-index.html",
       "short": "lorem ipsum doloret sit amet",
       "long": "This is the first demo showcasing features."


### PR DESCRIPTION
## Summary
- rename the creative workspace to Orbit OS v 0.1.0 and Docu Monster Studio Pro 0.1.0 across the desktop app configuration and listings
- refresh the Docu Monster Studio Pro document template and UI chrome with the new branding, including autosave keys and release notes
- hide frame resize handles until a frame is selected and keep them out of printed/PDF exports while removing the unused system name prompt

## Testing
- python -m json.tool apps/app1/app-data/app1.json
- python -m json.tool data/index.json

------
https://chatgpt.com/codex/tasks/task_e_68d6732b4160832a997274ab761c2902