### PR TITLE
Speed up Terrain loader spinner animation

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -88,17 +88,23 @@
       letter-spacing: 0.32em;
     }
     #loader .loader-logo {
+      --logo-tilt: 14deg;
+      --logo-spin-duration: 2.4s;
       width: min(220px, 40vw);
       aspect-ratio: 1 / 1;
       perspective: 900px;
       position: relative;
       filter: drop-shadow(0 22px 32px rgba(0, 0, 0, 0.55));
+      contain: layout paint;
     }
     #loader .loader-logo svg {
       width: 100%;
       height: 100%;
       transform-style: preserve-3d;
-      animation: logo-precess 8s linear infinite;
+      backface-visibility: hidden;
+      will-change: transform;
+      transform: rotateX(var(--logo-tilt)) rotateY(0deg);
+      animation: logo-spin var(--logo-spin-duration) linear infinite;
     }
     #loader .loader-logo .logo-glow {
       fill: url(#logo-gradient);
@@ -114,10 +120,14 @@
       letter-spacing: 0.32em;
       color: rgba(255, 255, 255, 0.72);
     }
-    @keyframes logo-precess {
-      0% { transform: rotateX(14deg) rotateY(0deg); }
-      50% { transform: rotateX(14deg) rotateY(180deg); }
-      100% { transform: rotateX(14deg) rotateY(360deg); }
+    @keyframes logo-spin {
+      from { transform: rotateX(var(--logo-tilt)) rotateY(0deg); }
+      to { transform: rotateX(var(--logo-tilt)) rotateY(360deg); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      #loader .loader-logo svg {
+        animation-duration: calc(var(--logo-spin-duration) * 2);
+      }
     }
     #loader #progress {
       color: var(--accent-orange);


### PR DESCRIPTION
## Summary
- speed up the Terrain loader spinner by shortening the rotation cycle and caching the tilt via CSS variables
- smooth out the animation with GPU-friendly transform hints and containment for the SVG logo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6838902f8832a8a45dcaa94b7540e