### PR TITLE
Rework Docu Monster layout columns

### DIFF
--- a/apps/app1/documonster.html
+++ b/apps/app1/documonster.html
@@ -20,7 +20,7 @@
     --ink:#111; --ink-soft:#444; --rule:#ddd; --paper:#fff; --thumb-bg:#c0c0c0;
     --font-ui:"Tahoma","Segoe UI","MS Sans Serif",ui-sans-serif,system-ui,sans-serif;
     --font-body:"Times New Roman","Noto Serif",ui-serif,serif;
-    --menu-h:28px; --ui-h:58px; --sidebar-w:228px;
+    --menu-h:28px; --sidebar-w:228px; --measure-w:260px; --workspace-pad:72px;
     --crop-l:7mm; --crop-w:0.25mm;
   }
 
@@ -40,8 +40,8 @@
   .menu-sep{ border-top:1px solid #808080; border-bottom:1px solid #fff; margin:4px 0; }
 
   /* ===== Toolbar ===== */
-  #ui{ position:sticky; top:var(--menu-h); z-index:1100; background:#c0c0c0; padding:6px; border-bottom:2px solid #808080; display:flex; align-items:center; gap:6px; flex-wrap:wrap; min-height:var(--ui-h); }
-  .win-group{ padding:6px; background:#c0c0c0; border:2px solid #808080; border-right-color:#fff; border-bottom-color:#fff; display:flex; align-items:center; gap:6px; flex-wrap:wrap; }
+  #ui{ position:fixed; top:var(--menu-h); left:0; bottom:0; width:var(--measure-w); z-index:1100; background:#c0c0c0; padding:12px; border-right:2px solid #808080; display:flex; flex-direction:column; align-items:stretch; gap:12px; overflow:auto; }
+  .win-group{ padding:6px; background:#c0c0c0; border:2px solid #808080; border-right-color:#fff; border-bottom-color:#fff; display:flex; align-items:center; gap:6px; flex-wrap:wrap; width:100%; }
   .win-btn{ padding:2px 8px; min-width:28px; background:#c0c0c0; border:2px solid #fff; border-right-color:#000; border-bottom-color:#000; cursor:pointer; font:12px var(--font-ui); }
   .win-btn:active{ border:2px solid #000; border-right-color:#fff; border-bottom-color:#fff; }
   .win-check{ display:inline-flex; align-items:center; gap:4px; font:12px var(--font-ui); }
@@ -60,7 +60,7 @@
   #frameInspector small{ font-size:11px; color:#333; }
 
   /* ===== Sidebar ===== */
-  #sidebar{ position:fixed; top:calc(var(--menu-h) + var(--ui-h)); left:0; bottom:0; width:var(--sidebar-w); background:#c0c0c0; border-right:2px solid #808080; overflow:auto; padding:6px; }
+  #sidebar{ position:fixed; top:var(--menu-h); left:var(--measure-w); bottom:0; width:var(--sidebar-w); background:#c0c0c0; border-right:2px solid #808080; overflow:auto; padding:12px 10px; z-index:1000; }
   #releaseCard{ background:#f7f7f7; border:2px solid #808080; border-right-color:#fff; border-bottom-color:#fff; padding:10px; font:11px var(--font-ui); margin-bottom:10px; color:#000; }
   #releaseCard h2{ font:13px var(--font-ui); margin:0 0 6px 0; color:#000080; }
   #releaseCard p{ margin:0 0 6px 0; }
@@ -74,8 +74,8 @@
 
   /* ===== Rulers ===== */
   #rulerTop, #rulerLeft{ position:fixed; background:#f2f2f2; color:#000; font:10px var(--font-ui); z-index:900; pointer-events:none; }
-  #rulerTop{ top:calc(var(--menu-h) + var(--ui-h)); left:calc(var(--sidebar-w) + 12px); height:28px; width:calc(var(--sheet-w) + 36px); border:1px solid #808080; border-left:none; display:block; }
-  #rulerLeft{ top:calc(var(--menu-h) + var(--ui-h) + 28px); left:calc(var(--sidebar-w) - 24px); width:36px; height:calc(var(--sheet-h) + 40px); border:1px solid #808080; border-top:none; display:block; }
+  #rulerTop{ top:calc(var(--menu-h) + 12px); left:calc(var(--measure-w) + var(--sidebar-w) + 12px); height:28px; width:calc(var(--sheet-w) + 36px); border:1px solid #808080; border-left:none; display:block; }
+  #rulerLeft{ top:calc(var(--menu-h) + 40px); left:calc(var(--measure-w) + var(--sidebar-w) - 24px); width:36px; height:calc(var(--sheet-h) + var(--workspace-pad)); border:1px solid #808080; border-top:none; display:block; }
   #rulerTop::before{ content:""; position:absolute; inset:0; background:
     repeating-linear-gradient(to right, rgba(0,0,0,0.3) 0, rgba(0,0,0,0.3) 1px, transparent 1px, transparent 3.7795px),
     repeating-linear-gradient(to right, rgba(0,0,0,0.6) 0, rgba(0,0,0,0.6) 1.3px, transparent 1.3px, transparent 37.795px),
@@ -96,8 +96,8 @@
   #rulerLeft .cm span{ left:2px; transform:translate(0,-50%); }
 
   /* ===== Pages ===== */
-  #pages{ margin-left:calc(var(--sidebar-w) + 36px); padding-left:20px; }
-  .sheet{ position:relative; width:var(--sheet-w); height:var(--sheet-h); background:var(--paper); color:var(--ink); box-shadow:0 0 0 2px #808080, 0 0 0 4px #fff; margin:18px auto; border:none; scroll-margin-top:calc(var(--menu-h) + var(--ui-h) + 14px); overflow:hidden; }
+  #pages{ margin-left:calc(var(--measure-w) + var(--sidebar-w) + 36px); padding:var(--workspace-pad) 20px 40px; }
+  .sheet{ position:relative; width:var(--sheet-w); height:var(--sheet-h); background:var(--paper); color:var(--ink); box-shadow:0 0 0 2px #808080, 0 0 0 4px #fff; margin:18px auto; border:none; scroll-margin-top:calc(var(--menu-h) + var(--workspace-pad)); overflow:hidden; }
   .sheet{ --inPage:var(--m-in); --outPage:var(--m-out); }
   .sheet.even{ --inPage:var(--m-out); --outPage:var(--m-in); }
   .sheet.theme-standard{ --paper:#fff; --ink:#111; --ink-soft:#444; }
@@ -340,7 +340,6 @@
       </div>
       <small>Edit values to reposition or update the selected frame.</small>
     </div>
-    <div class="spacer"></div>
     <div class="win-group">
       <span class="win-stat" id="status">Ready.</span>
       <span class="win-stat" id="ver">Orbit OS v 0.1.0 • Docu Monster Studio Pro 0.1.0</span>


### PR DESCRIPTION
## Summary
- move the Docu Monster Studio Pro toolbar into a fixed measurements column for the new three-panel layout
- reposition the thumbnails sidebar and rulers to line up with the controls column and full page view
- tweak page padding and scroll offsets so sheets align with the rulers after the layout change

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d688bbe674832a940c0df680efe3d4