### PR TITLE
Make Terrain signal log foldable

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -500,10 +500,64 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
+      gap: 10px;
       font-size: 0.62rem;
       color: var(--accent-orange);
       text-transform: uppercase;
       letter-spacing: 0.16em;
+    }
+    #console-dock .console-actions {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    #console-dock .console-status {
+      color: rgba(255, 255, 255, 0.72);
+      letter-spacing: 0.12em;
+    }
+    #console-fold-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 9px;
+      border: 1px solid rgba(255, 255, 255, 0.22);
+      background: rgba(2, 8, 23, 0.45);
+      color: var(--text-white);
+      font-family: inherit;
+      font-size: 0.52rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      cursor: pointer;
+      transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    }
+    #console-fold-btn:hover {
+      background: rgba(255, 139, 47, 0.2);
+      border-color: rgba(255, 139, 47, 0.55);
+      transform: translateY(-1px);
+    }
+    #console-fold-btn:active {
+      transform: translateY(1px);
+    }
+    #console-fold-btn .fold-icon {
+      width: 14px;
+      height: 14px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      transition: transform 0.35s ease;
+    }
+    #console-fold-btn .fold-icon svg {
+      width: 100%;
+      height: 100%;
+      fill: currentColor;
+      transform-origin: center;
+      transition: transform 0.35s ease;
+    }
+    #console-fold-btn .fold-label {
+      letter-spacing: 0.1em;
+    }
+    #console-dock.folded #console-fold-btn .fold-icon svg {
+      transform: rotate(-90deg);
     }
     #console-dock #console-log {
       position: relative;
@@ -515,10 +569,20 @@
       background: rgba(0, 0, 0, 0.3);
       border: 1px solid rgba(255, 255, 255, 0.1);
       pointer-events: auto;
+      transition: max-height 0.35s ease, opacity 0.3s ease;
     }
     #console-dock #console-log .console-line {
       margin-bottom: 4px;
       white-space: pre-wrap;
+    }
+    #console-dock.folded #console-log {
+      max-height: 0;
+      opacity: 0;
+      padding-top: 0;
+      padding-bottom: 0;
+      border-color: rgba(255, 255, 255, 0.06);
+      pointer-events: none;
+      overflow: hidden;
     }
   </style>
 </head>
@@ -586,8 +650,18 @@
   <div id="fps"></div>
   <div id="console-dock">
     <div class="console-headline">
-      <span>Signal Log</span>
-      <span>Expanded</span>
+      <span class="console-title">Signal Log</span>
+      <div class="console-actions">
+        <span id="console-status" class="console-status">Expanded</span>
+        <button id="console-fold-btn" type="button" aria-expanded="true" aria-controls="console-log">
+          <span class="fold-icon" aria-hidden="true">
+            <svg viewBox="0 0 16 16" role="presentation" focusable="false">
+              <path d="M4.2 2.8a1 1 0 0 1 1.6 0l4 5a1 1 0 0 1 0 1.2l-4 5a1 1 0 0 1-1.6-1.2L7.7 8 4.2 4a1 1 0 0 1 0-1.2z"></path>
+            </svg>
+          </span>
+          <span class="fold-label">Fold Log</span>
+        </button>
+      </div>
     </div>
     <div id="console-log" role="log" aria-live="polite"></div>
   </div>
@@ -619,8 +693,31 @@
   import { initConsoleLogs } from '../../shared/consolelogs.js';
 
   const consoleLogEl = document.getElementById('console-log');
+  const consoleDock = document.getElementById('console-dock');
+  const consoleFoldBtn = document.getElementById('console-fold-btn');
+  const consoleStatus = document.getElementById('console-status');
+  const consoleFoldLabel = consoleFoldBtn?.querySelector('.fold-label');
+
   initConsoleLogs({ container: consoleLogEl, removeAfter: null });
   console.log('Console dock expanded for extended diagnostics.');
+
+  if (consoleFoldBtn && consoleDock) {
+    const updateConsoleFold = (folded) => {
+      if (consoleStatus) {
+        consoleStatus.textContent = folded ? 'Folded' : 'Expanded';
+      }
+      if (consoleFoldLabel) {
+        consoleFoldLabel.textContent = folded ? 'Unfold Log' : 'Fold Log';
+      }
+    };
+    consoleFoldBtn.addEventListener('click', () => {
+      const isFolded = consoleDock.classList.toggle('folded');
+      consoleFoldBtn.setAttribute('aria-expanded', String(!isFolded));
+      updateConsoleFold(isFolded);
+      console.log(`Signal log ${isFolded ? 'folded' : 'expanded'}.`);
+    });
+    updateConsoleFold(consoleDock.classList.contains('folded'));
+  }
 
   const hudElements = {
     position: document.querySelector('[data-hud="position"]'),


### PR DESCRIPTION
## Summary
- add folding controls and styling to the Terrain signal log dock
- update the log dock markup with a status label and fold button
- wire up JavaScript to toggle the dock, update labels, and log state changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6895a0c44832aa41ce9bf4336ffae