### PR TITLE
Create minimal single-file Orbit OS deck

### DIFF
--- a/mini.html
+++ b/mini.html
@@ -3,22 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Orbit OS — Minimal Flight Deck</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
+  <title>Orbit OS — Mini Deck</title>
   <style>
     :root {
-      --white: #ffffff;
-      --orange: #ff8a3d;
-      --paris-blue: #4f86f7;
-      --dark-navy: #07162c;
-      --black: #000000;
-      --sand-10: #f5efe4;
-      --sand-30: #e4d4b8;
-      --sand-60: #c7a874;
-      --sand-90: #8a6a36;
-      font-family: "Space Grotesk", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --bg: #0b1323;
+      --panel: #111b30;
+      --panel-border: rgba(255, 255, 255, 0.08);
+      --text: #f5f7ff;
+      --muted: rgba(245, 247, 255, 0.64);
+      --accent: #66aaff;
+      --accent-soft: rgba(102, 170, 255, 0.16);
+      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     }
 
     * {
@@ -28,160 +23,138 @@
     body {
       margin: 0;
       min-height: 100vh;
-      background: radial-gradient(circle at 20% 20%, rgba(79, 134, 247, 0.18), transparent 45%),
-        radial-gradient(circle at 80% 10%, rgba(255, 138, 61, 0.12), transparent 50%),
-        linear-gradient(160deg, var(--dark-navy), var(--black));
-      color: var(--white);
+      background: radial-gradient(circle at 15% 20%, rgba(102, 170, 255, 0.18), transparent 45%),
+        radial-gradient(circle at 85% 10%, rgba(255, 170, 102, 0.14), transparent 50%),
+        linear-gradient(160deg, #050910, var(--bg));
+      color: var(--text);
       display: flex;
       flex-direction: column;
     }
 
-    .top-bar {
-      height: 56px;
+    header {
       display: flex;
-      align-items: center;
       justify-content: space-between;
-      padding: 0 28px;
-      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-      background: rgba(7, 22, 44, 0.72);
-      backdrop-filter: blur(18px);
+      align-items: center;
+      padding: 0.85rem 1.5rem;
+      border-bottom: 1px solid var(--panel-border);
+      background: rgba(11, 19, 35, 0.85);
+      backdrop-filter: blur(12px);
+      position: sticky;
+      top: 0;
+      z-index: 100;
     }
 
-    .top-bar h1 {
-      font-size: 1rem;
-      font-weight: 500;
-      letter-spacing: 0.14em;
+    header h1 {
+      font-size: 0.95rem;
       text-transform: uppercase;
+      letter-spacing: 0.16em;
       margin: 0;
-      color: var(--sand-10);
+      color: var(--muted);
     }
 
-    .status-indicators {
-      display: flex;
-      align-items: center;
-      gap: 18px;
+    header span {
+      font-variant-numeric: tabular-nums;
       font-size: 0.85rem;
-      color: var(--sand-30);
+      color: var(--muted);
     }
 
-    .status-indicators span {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-    }
-
-    .status-dot {
-      width: 8px;
-      height: 8px;
-      border-radius: 999px;
-      background: var(--orange);
-      box-shadow: 0 0 12px rgba(255, 138, 61, 0.6);
-    }
-
-    .desktop {
+    main {
       flex: 1;
-      position: relative;
-      overflow: hidden;
-      padding: clamp(16px, 3vw, 36px);
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-      gap: clamp(16px, 3vw, 32px);
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: clamp(16px, 3vw, 28px);
+      padding: clamp(18px, 4vw, 38px);
       align-content: flex-start;
     }
 
-    .icon-card {
-      background: rgba(7, 22, 44, 0.58);
-      border: 1px solid rgba(255, 255, 255, 0.08);
-      border-radius: 18px;
+    .icon {
+      border-radius: 16px;
+      border: 1px solid var(--panel-border);
+      background: rgba(11, 19, 35, 0.75);
       padding: 18px;
-      min-height: 120px;
+      min-height: 128px;
       display: flex;
       flex-direction: column;
       justify-content: space-between;
+      gap: 12px;
       cursor: pointer;
-      transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
-      position: relative;
-      isolation: isolate;
+      transition: border-color 0.18s ease, transform 0.18s ease, background 0.18s ease;
     }
 
-    .icon-card::after {
-      content: "";
-      position: absolute;
-      inset: 0;
-      border-radius: 18px;
-      background: linear-gradient(140deg, rgba(255, 138, 61, 0.16), rgba(79, 134, 247, 0.24));
-      opacity: 0;
-      transition: opacity 0.2s ease;
-      z-index: -1;
+    .icon:hover,
+    .icon:focus-visible {
+      border-color: rgba(102, 170, 255, 0.4);
+      transform: translateY(-3px);
+      outline: none;
+      background: rgba(11, 19, 35, 0.92);
     }
 
-    .icon-card:hover {
-      transform: translateY(-4px);
-      border-color: rgba(255, 255, 255, 0.18);
-    }
-
-    .icon-card:hover::after {
-      opacity: 1;
+    .icon:focus-visible {
+      box-shadow: 0 0 0 3px rgba(102, 170, 255, 0.3);
     }
 
     .icon-figure {
-      width: 48px;
-      height: 48px;
+      width: 46px;
+      height: 46px;
       border-radius: 14px;
-      background: linear-gradient(135deg, var(--paris-blue), rgba(79, 134, 247, 0.42));
+      background: rgba(102, 170, 255, 0.12);
+      color: var(--accent);
       display: grid;
       place-items: center;
-      color: var(--white);
       font-size: 1.35rem;
-      margin-bottom: 14px;
     }
 
-    .icon-title {
+    .icon h2 {
       font-size: 0.95rem;
-      font-weight: 500;
-      color: var(--sand-10);
-      letter-spacing: 0.04em;
+      margin: 0;
+      font-weight: 600;
+      color: var(--text);
     }
 
-    .icon-subtitle {
-      font-size: 0.75rem;
-      color: var(--sand-30);
+    .icon p {
+      margin: 0;
+      font-size: 0.8rem;
+      color: var(--muted);
       line-height: 1.4;
+    }
+
+    .tag {
+      font-size: 0.7rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: rgba(245, 247, 255, 0.5);
     }
 
     .window {
       position: absolute;
-      top: 20%;
-      left: 20%;
-      min-width: 260px;
-      max-width: min(480px, 85vw);
-      background: rgba(7, 22, 44, 0.88);
-      border: 1px solid rgba(255, 255, 255, 0.08);
+      min-width: 280px;
+      max-width: min(460px, 90vw);
+      background: rgba(11, 19, 35, 0.94);
+      border: 1px solid var(--panel-border);
       border-radius: 18px;
-      backdrop-filter: blur(16px);
       box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
       display: flex;
       flex-direction: column;
-      animation: scale-in 220ms ease;
+      animation: fade-in 180ms ease;
     }
 
-    @keyframes scale-in {
+    @keyframes fade-in {
       from {
-        transform: scale(0.92) translateY(12px);
+        transform: translateY(12px) scale(0.95);
         opacity: 0;
       }
       to {
-        transform: scale(1) translateY(0);
+        transform: translateY(0) scale(1);
         opacity: 1;
       }
     }
 
     .window-header {
       display: flex;
-      align-items: center;
       justify-content: space-between;
-      padding: 16px 20px;
-      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      align-items: center;
+      padding: 14px 18px;
+      border-bottom: 1px solid var(--panel-border);
       cursor: grab;
       gap: 12px;
     }
@@ -191,161 +164,124 @@
     }
 
     .window-title {
-      font-size: 0.95rem;
-      font-weight: 500;
-      color: var(--white);
-      letter-spacing: 0.08em;
+      margin: 0;
+      font-size: 0.85rem;
+      letter-spacing: 0.12em;
       text-transform: uppercase;
     }
 
-    .window-actions button {
+    .window-close {
       width: 28px;
       height: 28px;
       border-radius: 50%;
       border: none;
-      background: rgba(255, 138, 61, 0.16);
-      color: var(--orange);
+      background: var(--accent-soft);
+      color: var(--accent);
+      font-size: 1rem;
+      cursor: pointer;
       display: grid;
       place-items: center;
-      cursor: pointer;
       transition: background 0.18s ease, color 0.18s ease;
     }
 
-    .window-actions button:hover {
-      background: var(--orange);
-      color: var(--black);
+    .window-close:hover {
+      background: var(--accent);
+      color: var(--bg);
     }
 
     .window-body {
-      padding: 20px;
-      display: flex;
-      flex-direction: column;
+      padding: 18px;
+      display: grid;
       gap: 16px;
-      color: var(--sand-10);
-      font-size: 0.95rem;
+      font-size: 0.9rem;
+      color: var(--muted);
       line-height: 1.6;
     }
 
     .window-body h2 {
       margin: 0;
       font-size: 1rem;
-      font-weight: 600;
-      color: var(--white);
+      color: var(--text);
     }
 
     .window-body p,
     .window-body li {
-      color: var(--sand-10);
+      color: var(--muted);
     }
 
     .window-body ul {
       margin: 0;
-      padding-left: 20px;
+      padding-left: 18px;
       display: grid;
       gap: 6px;
     }
 
-    .window-body strong {
-      color: var(--white);
-    }
-
-    .note-area {
+    textarea {
       width: 100%;
       min-height: 160px;
-      background: rgba(245, 239, 228, 0.08);
-      border: 1px solid rgba(245, 239, 228, 0.18);
       border-radius: 12px;
-      color: var(--sand-10);
-      padding: 16px;
-      font-size: 0.95rem;
-      font-family: "Space Grotesk", sans-serif;
+      border: 1px solid rgba(102, 170, 255, 0.22);
+      background: rgba(102, 170, 255, 0.06);
+      padding: 14px;
+      font-family: inherit;
+      font-size: 0.9rem;
+      color: var(--text);
       resize: vertical;
     }
 
+    textarea:focus {
+      outline: 2px solid rgba(102, 170, 255, 0.45);
+    }
+
     .clock-face {
-      font-size: 2.4rem;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      color: var(--white);
+      font-size: 2.2rem;
       text-align: center;
+      font-variant-numeric: tabular-nums;
+      color: var(--text);
     }
 
     .clock-subline {
       text-align: center;
-      font-size: 0.8rem;
+      letter-spacing: 0.24em;
+      font-size: 0.7rem;
       text-transform: uppercase;
-      letter-spacing: 0.2em;
-      color: var(--sand-30);
+      color: rgba(245, 247, 255, 0.55);
     }
 
-    .palette-grid {
+    .palette {
       display: grid;
       gap: 12px;
     }
 
     .swatch {
+      border-radius: 10px;
+      padding: 12px 14px;
       display: flex;
-      align-items: center;
       justify-content: space-between;
-      padding: 12px 16px;
-      border-radius: 12px;
-      color: var(--black);
-      font-weight: 500;
-    }
-
-    .swatch:nth-child(1) {
-      background: var(--sand-10);
-    }
-
-    .swatch:nth-child(2) {
-      background: var(--sand-30);
-    }
-
-    .swatch:nth-child(3) {
-      background: var(--sand-60);
-      color: var(--white);
-    }
-
-    .swatch:nth-child(4) {
-      background: var(--sand-90);
-      color: var(--white);
-    }
-
-    .mini-tag {
-      display: inline-flex;
       align-items: center;
-      gap: 8px;
-      font-size: 0.75rem;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: var(--sand-30);
+      font-weight: 600;
+      color: #0b1323;
     }
 
-    .mini-tag::before {
-      content: "";
-      width: 22px;
-      height: 1px;
-      background: rgba(255, 255, 255, 0.16);
-    }
+    .swatch:nth-child(1) { background: #f5efe4; }
+    .swatch:nth-child(2) { background: #e4d4b8; }
+    .swatch:nth-child(3) { background: #c7a874; color: #f5f7ff; }
+    .swatch:nth-child(4) { background: #8a6a36; color: #f5f7ff; }
 
     @media (max-width: 720px) {
-      .top-bar {
-        padding: 0 18px;
-      }
-
-      .desktop {
-        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      main {
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
       }
 
       .window {
-        left: 50%;
+        left: 50% !important;
         transform: translateX(-50%);
-        width: min(90vw, 420px);
+        width: min(92vw, 420px);
       }
     }
 
     @media (prefers-reduced-motion: reduce) {
-      .icon-card,
+      .icon,
       .window {
         transition: none;
         animation: none;
@@ -354,62 +290,57 @@
   </style>
 </head>
 <body>
-  <header class="top-bar">
-    <h1>Orbit OS Minimal Deck</h1>
-    <div class="status-indicators">
-      <span><span class="status-dot" aria-hidden="true"></span>Systems nominal</span>
-      <span id="deck-clock" aria-live="polite">00:00</span>
-    </div>
+  <header>
+    <h1>Orbit OS Mini</h1>
+    <span id="deck-clock" aria-live="polite">00:00</span>
   </header>
-  <main class="desktop" aria-label="Orbit desktop">
-    <article class="icon-card" data-app="mission" tabindex="0">
+  <main aria-label="Orbit desktop">
+    <article class="icon" data-app="mission" tabindex="0">
+      <div class="icon-figure" aria-hidden="true">🛰️</div>
       <div>
-        <div class="icon-figure" aria-hidden="true">🛰️</div>
-        <h2 class="icon-title">Mission Brief</h2>
-        <p class="icon-subtitle">Deep analysis of the legacy Orbit OS stack.</p>
+        <h2>Mission Brief</h2>
+        <p>Deep analysis of the legacy Orbit OS stack.</p>
       </div>
-      <span class="mini-tag">intel</span>
+      <span class="tag">intel</span>
     </article>
-    <article class="icon-card" data-app="notes" tabindex="0">
+    <article class="icon" data-app="notes" tabindex="0">
+      <div class="icon-figure" aria-hidden="true">🗒️</div>
       <div>
-        <div class="icon-figure" aria-hidden="true">🗒️</div>
-        <h2 class="icon-title">Field Notes</h2>
-        <p class="icon-subtitle">Jot orbit observations. Persists locally.</p>
+        <h2>Field Notes</h2>
+        <p>Jot orbit observations. Persists locally.</p>
       </div>
-      <span class="mini-tag">memory</span>
+      <span class="tag">memory</span>
     </article>
-    <article class="icon-card" data-app="clock" tabindex="0">
+    <article class="icon" data-app="clock" tabindex="0">
+      <div class="icon-figure" aria-hidden="true">⏱️</div>
       <div>
-        <div class="icon-figure" aria-hidden="true">⏱️</div>
-        <h2 class="icon-title">Chronometer</h2>
-        <p class="icon-subtitle">Synchronized mission time feed.</p>
+        <h2>Chronometer</h2>
+        <p>Synchronized mission time feed.</p>
       </div>
-      <span class="mini-tag">time</span>
+      <span class="tag">time</span>
     </article>
-    <article class="icon-card" data-app="palette" tabindex="0">
+    <article class="icon" data-app="palette" tabindex="0">
+      <div class="icon-figure" aria-hidden="true">🎨</div>
       <div>
-        <div class="icon-figure" aria-hidden="true">🎨</div>
-        <h2 class="icon-title">Palette Map</h2>
-        <p class="icon-subtitle">Orbit tones with four sand-inspired shades.</p>
+        <h2>Palette Map</h2>
+        <p>Orbit tones with four sand-inspired shades.</p>
       </div>
-      <span class="mini-tag">visual</span>
+      <span class="tag">visual</span>
     </article>
   </main>
   <template id="window-template">
     <section class="window" role="dialog" aria-modal="false">
       <div class="window-header">
         <span class="window-title"></span>
-        <div class="window-actions">
-          <button type="button" class="window-close" aria-label="Close window">×</button>
-        </div>
+        <button type="button" class="window-close" aria-label="Close window">×</button>
       </div>
       <div class="window-body"></div>
     </section>
   </template>
   <script>
-    const desktop = document.querySelector('.desktop');
-    const windowTemplate = document.getElementById('window-template');
-    let focusIndex = 8;
+    const desktop = document.querySelector('main');
+    const template = document.getElementById('window-template');
+    let focusIndex = 6;
 
     const apps = {
       mission: {
@@ -434,15 +365,19 @@
       notes: {
         title: 'Field Notes',
         render() {
+          const STORAGE_KEY = 'orbit-mini-notes';
           const wrapper = document.createElement('div');
           wrapper.innerHTML = `
-            <p>Notes sync to local storage so drafts survive refreshes.</p>
-            <textarea class="note-area" placeholder="Type mission notes here…"></textarea>
+            <h2>Field Notes</h2>
+            <p>Write observations and they will sync locally to this device.</p>
+            <textarea placeholder="Mission notes..." aria-label="Mission notes area"></textarea>
           `;
           const textarea = wrapper.querySelector('textarea');
-          const STORAGE_KEY = 'orbit-minimal-notes';
           textarea.value = localStorage.getItem(STORAGE_KEY) || '';
           textarea.addEventListener('input', () => {
+            localStorage.setItem(STORAGE_KEY, textarea.value);
+          });
+          wrapper.addEventListener('removed', () => {
             localStorage.setItem(STORAGE_KEY, textarea.value);
           });
           return wrapper;
@@ -475,7 +410,7 @@
           const wrapper = document.createElement('div');
           wrapper.innerHTML = `
             <p>Five primaries anchor the interface. Sand tones add a grounded analogue bridge between the cool blues and energetic orange.</p>
-            <div class="palette-grid">
+            <div class="palette">
               <div class="swatch">Sand 10<span>#F5EFE4</span></div>
               <div class="swatch">Sand 30<span>#E4D4B8</span></div>
               <div class="swatch">Sand 60<span>#C7A874</span></div>
@@ -490,14 +425,14 @@
     function openWindow(appKey) {
       const app = apps[appKey];
       if (!app) return;
-      const node = windowTemplate.content.firstElementChild.cloneNode(true);
+      const node = template.content.firstElementChild.cloneNode(true);
       const body = node.querySelector('.window-body');
       node.querySelector('.window-title').textContent = app.title;
       const view = app.render();
       body.appendChild(view);
       desktop.appendChild(node);
-      const left = Math.max(24, Math.min(window.innerWidth - 360, 80 + Math.random() * 160));
-      const top = Math.max(24, Math.min(window.innerHeight - 320, 80 + Math.random() * 140));
+      const left = Math.max(18, Math.min(window.innerWidth - 340, 72 + Math.random() * 120));
+      const top = Math.max(18, Math.min(window.innerHeight - 320, 72 + Math.random() * 120));
       node.style.left = `${left}px`;
       node.style.top = `${top}px`;
       focusWindow(node);
@@ -527,8 +462,7 @@
         offsetY = event.clientY - rect.top;
         node.setPointerCapture(event.pointerId);
         node.style.transition = 'none';
-        focusIndex += 1;
-        node.style.zIndex = focusIndex;
+        focusWindow(node);
         header.addEventListener('pointermove', pointerMove);
         header.addEventListener('pointerup', pointerUp, { once: true });
       }
@@ -546,14 +480,14 @@
     }
 
     desktop.addEventListener('click', (event) => {
-      const card = event.target.closest('.icon-card');
+      const card = event.target.closest('.icon');
       if (!card) return;
       openWindow(card.dataset.app);
     });
 
     desktop.addEventListener('keydown', (event) => {
       if (event.key === 'Enter' || event.key === ' ') {
-        const card = event.target.closest('.icon-card');
+        const card = event.target.closest('.icon');
         if (!card) return;
         event.preventDefault();
         openWindow(card.dataset.app);


### PR DESCRIPTION
## Summary
- replace the bloated Orbit OS demo with a compact `mini.html` deck
- retain all desktop interactions while simplifying the layout and styling for the mini build

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d694f682e0832a8021b8eadda1a733