### PR TITLE
Add single-file Orbit OS experience

### DIFF
--- a/mini2.html
+++ b/mini2.html
@@ -1,0 +1,954 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Orbit OS — Single File Edition</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      color-scheme: dark;
+      font-size: 18px;
+      --desktop-bg: radial-gradient(circle at 10% 15%, rgba(0, 255, 255, 0.12), transparent 55%),
+        radial-gradient(circle at 90% 8%, rgba(255, 120, 0, 0.16), transparent 52%),
+        linear-gradient(160deg, #020b27, #00103a 52%, #001f3f 100%);
+      --panel-light: #1c2f63;
+      --panel-dark: #08142d;
+      --chrome-border-light: #ffffff;
+      --chrome-border-dark: #0a214d;
+      --chrome-shadow: rgba(0, 0, 0, 0.65);
+      --accent: #4ec9ff;
+      --accent-soft: rgba(78, 201, 255, 0.2);
+      --text-strong: #f5f7ff;
+      --text-muted: rgba(245, 247, 255, 0.7);
+    }
+
+    *, *::before, *::after {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "VT323", system-ui, monospace;
+      letter-spacing: 0.02em;
+      background: #020b27;
+      display: grid;
+      place-items: stretch;
+      color: var(--text-strong);
+      user-select: none;
+    }
+
+    .desktop {
+      position: relative;
+      min-height: 100vh;
+      overflow: hidden;
+      background: var(--desktop-bg);
+      display: flex;
+      flex-direction: column;
+      isolation: isolate;
+    }
+
+    .desktop::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.18), rgba(0, 0, 0, 0.18) 2px, transparent 2px, transparent 4px);
+      mix-blend-mode: screen;
+      pointer-events: none;
+      opacity: 0.35;
+      z-index: 2;
+    }
+
+    .desktop::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: 10px;
+      box-shadow: inset 0 0 60px rgba(0, 0, 0, 0.65);
+      pointer-events: none;
+      z-index: 1;
+    }
+
+    .menu-bar {
+      position: relative;
+      z-index: 5;
+      display: flex;
+      align-items: center;
+      gap: 18px;
+      padding: 10px 18px;
+      background: linear-gradient(to bottom, rgba(22, 51, 110, 0.95), rgba(5, 14, 34, 0.95));
+      border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+      box-shadow: 0 18px 35px rgba(0, 0, 0, 0.45);
+      font-size: 1.1rem;
+    }
+
+    .menu-item {
+      position: relative;
+      cursor: pointer;
+      padding: 4px 10px;
+      border-radius: 6px;
+      transition: background 0.18s ease;
+    }
+
+    .menu-item:focus-visible,
+    .menu-item[aria-expanded="true"],
+    .menu-item:hover {
+      outline: none;
+      background: rgba(78, 201, 255, 0.2);
+    }
+
+    .dropdown {
+      position: absolute;
+      top: calc(100% + 6px);
+      left: 0;
+      background: rgba(8, 20, 45, 0.92);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 10px;
+      box-shadow: 0 18px 40px rgba(0, 0, 0, 0.55);
+      padding: 10px 0;
+      min-width: 210px;
+      display: none;
+    }
+
+    .dropdown[aria-hidden="false"] {
+      display: grid;
+      gap: 4px;
+    }
+
+    .dropdown button,
+    .dropdown a {
+      text-align: left;
+      background: none;
+      border: none;
+      color: var(--text-strong);
+      padding: 8px 16px;
+      font: inherit;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      transition: background 0.18s ease;
+    }
+
+    .dropdown button:hover,
+    .dropdown a:hover,
+    .dropdown button:focus-visible,
+    .dropdown a:focus-visible {
+      background: rgba(78, 201, 255, 0.2);
+      outline: none;
+    }
+
+    .clock-display {
+      margin-left: auto;
+      letter-spacing: 0.08em;
+      font-size: 1.05rem;
+      color: var(--text-muted);
+    }
+
+    .status-strip {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 6px 12px;
+      margin: 0 18px 18px;
+      border-radius: 8px;
+      background: rgba(8, 20, 45, 0.72);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: inset 0 0 0 1px rgba(78, 201, 255, 0.12);
+      z-index: 4;
+      position: relative;
+    }
+
+    .status-strip span {
+      color: var(--text-muted);
+      letter-spacing: 0.06em;
+      font-size: 0.95rem;
+    }
+
+    .desktop-icons {
+      position: relative;
+      z-index: 3;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 28px;
+      padding: clamp(32px, 4vw, 60px);
+      align-content: start;
+    }
+
+    .icon {
+      background: rgba(8, 20, 45, 0.78);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 18px;
+      padding: 18px 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      align-items: flex-start;
+      text-align: left;
+      cursor: pointer;
+      transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+    }
+
+    .icon:focus-visible,
+    .icon:hover {
+      outline: none;
+      border-color: rgba(78, 201, 255, 0.45);
+      background: rgba(13, 34, 70, 0.94);
+      transform: translateY(-6px);
+    }
+
+    .icon-figure {
+      width: 54px;
+      height: 54px;
+      border-radius: 16px;
+      display: grid;
+      place-items: center;
+      font-size: 1.6rem;
+      background: rgba(78, 201, 255, 0.16);
+      color: var(--accent);
+      box-shadow: inset 0 0 0 1px rgba(78, 201, 255, 0.3);
+    }
+
+    .icon h3 {
+      margin: 0;
+      font-size: 1.1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--text-strong);
+    }
+
+    .icon p {
+      margin: 0;
+      font-size: 0.95rem;
+      color: var(--text-muted);
+      line-height: 1.4;
+    }
+
+    .icon .tag {
+      text-transform: uppercase;
+      font-size: 0.75rem;
+      letter-spacing: 0.14em;
+      color: rgba(245, 247, 255, 0.5);
+    }
+
+    .window-layer {
+      position: absolute;
+      inset: 0;
+      z-index: 4;
+      pointer-events: none;
+    }
+
+    .window {
+      position: absolute;
+      min-width: 320px;
+      max-width: min(520px, 92vw);
+      max-height: min(520px, 80vh);
+      background: linear-gradient(180deg, rgba(25, 48, 98, 0.95), rgba(7, 17, 36, 0.96));
+      border-radius: 22px;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      box-shadow: 0 28px 80px rgba(0, 0, 0, 0.55);
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      transform-origin: center;
+      animation: window-pop 200ms ease;
+      pointer-events: auto;
+    }
+
+    .window.is-maximized {
+      max-width: none;
+      max-height: none;
+      border-radius: 18px;
+    }
+
+    @keyframes window-pop {
+      from {
+        transform: translateY(18px) scale(0.92);
+        opacity: 0;
+      }
+      to {
+        transform: translateY(0) scale(1);
+        opacity: 1;
+      }
+    }
+
+    .window-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 14px 18px;
+      background: linear-gradient(90deg, rgba(78, 201, 255, 0.16), transparent);
+      cursor: grab;
+      user-select: none;
+    }
+
+    .window-header:active {
+      cursor: grabbing;
+    }
+
+    .window-title {
+      flex: 1;
+      margin: 0;
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+    }
+
+    .window-controls {
+      display: flex;
+      gap: 8px;
+    }
+
+    .window-btn {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      border: none;
+      color: var(--text-strong);
+      background: rgba(78, 201, 255, 0.22);
+      font-size: 0.9rem;
+      display: grid;
+      place-items: center;
+      cursor: pointer;
+      transition: background 0.18s ease, transform 0.18s ease;
+    }
+
+    .window-btn:hover {
+      background: var(--accent);
+      transform: translateY(-1px);
+    }
+
+    .window-body {
+      padding: 20px;
+      display: grid;
+      gap: 16px;
+      font-size: 1rem;
+      color: var(--text-muted);
+      overflow: auto;
+    }
+
+    .window-body h2 {
+      margin: 0;
+      font-size: 1.2rem;
+      color: var(--text-strong);
+    }
+
+    .window-body p {
+      margin: 0;
+      line-height: 1.6;
+    }
+
+    .window-body ul {
+      margin: 0;
+      padding-left: 20px;
+      display: grid;
+      gap: 8px;
+    }
+
+    .window-body code {
+      font-family: "VT323", monospace;
+      font-size: 1rem;
+      background: rgba(78, 201, 255, 0.16);
+      padding: 0 6px;
+      border-radius: 4px;
+      color: var(--accent);
+    }
+
+    textarea {
+      width: 100%;
+      min-height: 160px;
+      border-radius: 14px;
+      border: 1px solid rgba(78, 201, 255, 0.45);
+      background: rgba(2, 11, 39, 0.65);
+      color: var(--text-strong);
+      font: inherit;
+      padding: 14px;
+      resize: vertical;
+    }
+
+    textarea:focus {
+      outline: 2px solid rgba(78, 201, 255, 0.45);
+    }
+
+    .terminal {
+      font-family: "VT323", monospace;
+      background: #020b27;
+      border-radius: 12px;
+      border: 1px solid rgba(78, 201, 255, 0.22);
+      padding: 12px 16px;
+      min-height: 220px;
+      display: grid;
+      gap: 8px;
+      overflow: hidden;
+    }
+
+    .terminal-line {
+      color: var(--accent);
+      letter-spacing: 0.08em;
+    }
+
+    .terminal-line span {
+      color: var(--text-strong);
+    }
+
+    .palette-grid {
+      display: grid;
+      gap: 14px;
+    }
+
+    .palette-swatch {
+      border-radius: 12px;
+      padding: 14px 16px;
+      font-weight: 600;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      text-transform: uppercase;
+      letter-spacing: 0.14em;
+    }
+
+    .timeline {
+      display: grid;
+      gap: 16px;
+    }
+
+    .timeline-item {
+      background: rgba(2, 11, 39, 0.65);
+      border-radius: 12px;
+      padding: 12px 16px;
+      border: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    .timeline-item h3 {
+      margin: 0 0 6px;
+      font-size: 1rem;
+      color: var(--text-strong);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .timeline-item p {
+      margin: 0;
+      color: var(--text-muted);
+    }
+
+    @media (max-width: 720px) {
+      :root { font-size: 16px; }
+      .desktop-icons {
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        padding: 28px;
+      }
+      .window {
+        left: 50% !important;
+        width: min(94vw, 520px);
+        transform: translateX(-50%);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="desktop" data-desktop>
+    <nav class="menu-bar" aria-label="Orbit OS menu bar">
+      <button class="menu-item" data-menu="system" aria-expanded="false">System</button>
+      <button class="menu-item" data-menu="apps" aria-expanded="false">Apps</button>
+      <button class="menu-item" data-menu="help" aria-expanded="false">Help</button>
+      <div class="clock-display" id="menu-clock" aria-live="polite">00:00</div>
+      <div class="dropdown" data-dropdown="system" aria-hidden="true">
+        <button type="button" data-action="toggle-theme">Switch Theme<span data-theme-label>Midnight</span></button>
+        <button type="button" data-action="show-about">About Orbit OS…</button>
+      </div>
+      <div class="dropdown" data-dropdown="apps" aria-hidden="true">
+        <button type="button" data-launch="terminal">Open Mission Terminal</button>
+        <button type="button" data-launch="notes">Open Field Notes</button>
+        <button type="button" data-launch="palette">Open Palette Atlas</button>
+        <button type="button" data-launch="timeline">Open Release Timeline</button>
+      </div>
+      <div class="dropdown" data-dropdown="help" aria-hidden="true">
+        <a href="#" data-launch="handbook">View Crew Handbook</a>
+        <button type="button" data-action="show-shortcuts">Keyboard Shortcuts</button>
+      </div>
+    </nav>
+    <div class="status-strip" role="status">
+      <span>Orbit OS v0.9.0 "Monarch"</span>
+      <span>Subsystems stable</span>
+      <span data-theme-status>Theme: Midnight</span>
+    </div>
+    <section class="desktop-icons" aria-label="Orbit OS desktop">
+      <button class="icon" data-app="mission">
+        <span class="icon-figure" aria-hidden="true">🛰️</span>
+        <h3>Mission Deck</h3>
+        <p>Capture the high-level audit of the classic Orbit stack.</p>
+        <span class="tag">intel</span>
+      </button>
+      <button class="icon" data-app="terminal">
+        <span class="icon-figure" aria-hidden="true">💻</span>
+        <h3>Mission Terminal</h3>
+        <p>Stream diagnostics from the simulated command relay.</p>
+        <span class="tag">ops</span>
+      </button>
+      <button class="icon" data-app="notes">
+        <span class="icon-figure" aria-hidden="true">🗒️</span>
+        <h3>Field Notes</h3>
+        <p>Keep persistent mission logs. Saved locally.</p>
+        <span class="tag">memory</span>
+      </button>
+      <button class="icon" data-app="palette">
+        <span class="icon-figure" aria-hidden="true">🎨</span>
+        <h3>Palette Atlas</h3>
+        <p>Review color harmonics driving the interface.</p>
+        <span class="tag">visual</span>
+      </button>
+      <button class="icon" data-app="timeline">
+        <span class="icon-figure" aria-hidden="true">🗂️</span>
+        <h3>Release Timeline</h3>
+        <p>Track milestone deployments across Orbit OS.</p>
+        <span class="tag">history</span>
+      </button>
+      <button class="icon" data-app="handbook">
+        <span class="icon-figure" aria-hidden="true">📘</span>
+        <h3>Crew Handbook</h3>
+        <p>Quick orientation for newly assigned cadets.</p>
+        <span class="tag">guide</span>
+      </button>
+    </section>
+    <div class="window-layer" id="window-layer" aria-live="polite"></div>
+    <template id="window-template">
+      <section class="window" role="dialog" aria-modal="false">
+        <header class="window-header">
+          <h2 class="window-title"></h2>
+          <div class="window-controls">
+            <button type="button" class="window-btn" data-action="minimize" title="Minimize">–</button>
+            <button type="button" class="window-btn" data-action="maximize" title="Maximize">⬜</button>
+            <button type="button" class="window-btn" data-action="close" title="Close">×</button>
+          </div>
+        </header>
+        <div class="window-body"></div>
+      </section>
+    </template>
+  </div>
+  <script>
+    const desktop = document.querySelector('[data-desktop]');
+    const windowLayer = document.getElementById('window-layer');
+    const template = document.getElementById('window-template');
+    const CLOCK = document.getElementById('menu-clock');
+    const STORAGE_KEY = 'orbit-os-notes';
+    const themeStatus = document.querySelector('[data-theme-status]');
+    const themeLabel = document.querySelector('[data-theme-label]');
+    let zIndexCounter = 10;
+    let currentTheme = localStorage.getItem('orbit-theme') || 'midnight';
+
+    const apps = {
+      mission: {
+        title: 'Mission Deck',
+        render() {
+          const wrapper = document.createElement('div');
+          wrapper.innerHTML = `
+            <h2>Legacy Stack Highlights</h2>
+            <p>The original Orbit OS desktop mixes CRT nostalgia with rich creative tooling. The single-file deck keeps the key briefing close at hand:</p>
+            <ul>
+              <li><strong>Immersive chrome:</strong> layered scanlines, curvature, and phosphor glows simulate a retro console.</li>
+              <li><strong>Declarative workspace:</strong> JSON payloads describe icons, launchers, and default window layouts.</li>
+              <li><strong>Utility suite:</strong> Terminals, note pads, studio embeds, and creative toys boot as independent modules.</li>
+              <li><strong>Embeddable studios:</strong> Orbit windows can frame bespoke authoring surfaces like DocuMonster Studio Pro.</li>
+            </ul>
+            <p>The mini build focuses on situational awareness while honoring the playful choreography of the original experience.</p>
+          `;
+          return wrapper;
+        }
+      },
+      terminal: {
+        title: 'Mission Terminal',
+        render() {
+          const wrapper = document.createElement('div');
+          const terminal = document.createElement('div');
+          terminal.className = 'terminal';
+          wrapper.append(terminal);
+          const lines = [
+            '[00:00] Booting ORBIT core services…',
+            '[00:03] Mounting /creative drive',
+            '[00:06] Loading window manager «Parallax»',
+            '[00:08] Syncing telemetry with L2 relay',
+            '[00:12] Calibrating neon bloom shaders',
+            '[00:15] All systems stable. Awaiting commands.'
+          ];
+          lines.forEach((line, index) => {
+            setTimeout(() => {
+              const row = document.createElement('div');
+              row.className = 'terminal-line';
+              row.innerHTML = `<span class="prompt">orbit@deck:</span> <span>${line}</span>`;
+              terminal.append(row);
+              terminal.scrollTop = terminal.scrollHeight;
+            }, index * 320);
+          });
+          return wrapper;
+        }
+      },
+      notes: {
+        title: 'Field Notes',
+        render() {
+          const wrapper = document.createElement('div');
+          wrapper.innerHTML = `
+            <h2>Mission Notes</h2>
+            <p>Entries are stored locally on this device. Your log travels with you across sessions.</p>
+            <textarea aria-label="Mission notes"></textarea>
+          `;
+          const textarea = wrapper.querySelector('textarea');
+          textarea.value = localStorage.getItem(STORAGE_KEY) || '';
+          textarea.addEventListener('input', () => {
+            localStorage.setItem(STORAGE_KEY, textarea.value);
+          });
+          wrapper.addEventListener('removed', () => {
+            localStorage.setItem(STORAGE_KEY, textarea.value);
+          });
+          return wrapper;
+        }
+      },
+      palette: {
+        title: 'Palette Atlas',
+        render() {
+          const wrapper = document.createElement('div');
+          wrapper.innerHTML = `
+            <p>Orbit thrives on a collision between midnight blues and energized amber. Sand tones bridge the spectrum.</p>
+            <div class="palette-grid">
+              <div class="palette-swatch" style="background:#f5efe4; color:#1b2236">Sand 10 <span>#F5EFE4</span></div>
+              <div class="palette-swatch" style="background:#e4d4b8; color:#1b2236">Sand 30 <span>#E4D4B8</span></div>
+              <div class="palette-swatch" style="background:#c7a874; color:#020b27">Sand 60 <span>#C7A874</span></div>
+              <div class="palette-swatch" style="background:#8a6a36; color:#f5efe4">Sand 90 <span>#8A6A36</span></div>
+              <div class="palette-swatch" style="background:#4ec9ff; color:#00103a">Ion 70 <span>#4EC9FF</span></div>
+            </div>
+          `;
+          return wrapper;
+        }
+      },
+      timeline: {
+        title: 'Release Timeline',
+        render() {
+          const wrapper = document.createElement('div');
+          wrapper.innerHTML = `
+            <p>Major check-ins from the archive of Orbit OS builds:</p>
+            <div class="timeline">
+              <div class="timeline-item">
+                <h3>v0.5.0 "Aurora" — 2023</h3>
+                <p>Introduced modular window bootstrap and the first scanline shader experiments.</p>
+              </div>
+              <div class="timeline-item">
+                <h3>v0.7.4 "Parallax" — 2024</h3>
+                <p>Expanded with creative studios, embedded iframe apps, and JSON-driven layouts.</p>
+              </div>
+              <div class="timeline-item">
+                <h3>v0.9.0 "Monarch" — 2025</h3>
+                <p>Refined motion system, added command relay, and tightened accessibility tooling.</p>
+              </div>
+            </div>
+          `;
+          return wrapper;
+        }
+      },
+      handbook: {
+        title: 'Crew Handbook',
+        render() {
+          const wrapper = document.createElement('div');
+          wrapper.innerHTML = `
+            <h2>Getting oriented</h2>
+            <p>Use <code>Enter</code> or double-click icons to launch. Drag headers to reposition. Press <code>Esc</code> to close focused windows.</p>
+            <ul>
+              <li><strong>Cmd/Ctrl + N</strong> — Open Field Notes</li>
+              <li><strong>Cmd/Ctrl + T</strong> — Open Mission Terminal</li>
+              <li><strong>Cmd/Ctrl + Shift + P</strong> — Toggle theme</li>
+            </ul>
+            <p>The single-file edition keeps assets inline so you can drop it anywhere and boot a mini desk instantly.</p>
+          `;
+          return wrapper;
+        }
+      },
+      about: {
+        title: 'About Orbit OS',
+        render() {
+          const wrapper = document.createElement('div');
+          wrapper.innerHTML = `
+            <h2>Orbit OS — Single File</h2>
+            <p>A condensed homage to the sprawling Orbit desktop. Built as a single HTML document so the experience can be shared without a build step.</p>
+            <p>Created by CyborgsDream. Crafted for rapid demos, workshops, or nostalgic trips through neon command decks.</p>
+          `;
+          return wrapper;
+        }
+      },
+      shortcuts: {
+        title: 'Keyboard Shortcuts',
+        render() {
+          const wrapper = document.createElement('div');
+          wrapper.innerHTML = `
+            <ul>
+              <li><code>Cmd/Ctrl + N</code> — Launch Field Notes</li>
+              <li><code>Cmd/Ctrl + T</code> — Launch Mission Terminal</li>
+              <li><code>Cmd/Ctrl + Shift + P</code> — Toggle theme</li>
+              <li><code>Esc</code> — Close focused window</li>
+              <li><code>Tab</code> — Cycle focus across icons and windows</li>
+            </ul>
+          `;
+          return wrapper;
+        }
+      }
+    };
+
+    function formatClock() {
+      const now = new Date();
+      const time = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      const date = now.toLocaleDateString([], { month: 'short', day: '2-digit' });
+      CLOCK.textContent = `${time} · ${date}`;
+    }
+
+    formatClock();
+    setInterval(formatClock, 1000);
+
+    function openWindow(appKey) {
+      const app = apps[appKey];
+      if (!app) return;
+      const node = template.content.firstElementChild.cloneNode(true);
+      const body = node.querySelector('.window-body');
+      node.dataset.app = appKey;
+      node.querySelector('.window-title').textContent = app.title;
+      const view = app.render();
+      body.append(view);
+      windowLayer.append(node);
+      positionWindow(node);
+      focusWindow(node);
+      enableDrag(node);
+      node.querySelectorAll('.window-btn').forEach(btn => {
+        btn.addEventListener('click', () => handleWindowControl(node, btn.dataset.action));
+      });
+      node.addEventListener('pointerdown', () => focusWindow(node));
+      node.addEventListener('keyup', (event) => {
+        if (event.key === 'Escape') closeWindow(node);
+      });
+      node.tabIndex = 0;
+      node.focus();
+    }
+
+    function positionWindow(node) {
+      const margin = 40;
+      const maxLeft = window.innerWidth - node.offsetWidth - margin;
+      const maxTop = window.innerHeight - node.offsetHeight - margin;
+      const left = Math.max(margin, Math.min(maxLeft, margin + Math.random() * 200));
+      const top = Math.max(margin + 60, Math.min(maxTop, margin + Math.random() * 160));
+      node.style.left = `${left}px`;
+      node.style.top = `${top}px`;
+    }
+
+    function focusWindow(node) {
+      zIndexCounter += 1;
+      node.style.zIndex = zIndexCounter;
+      node.classList.add('is-focused');
+      windowLayer.querySelectorAll('.window').forEach(win => {
+        if (win !== node) win.classList.remove('is-focused');
+      });
+    }
+
+    function closeWindow(node) {
+      node.dispatchEvent(new Event('removed', { bubbles: true }));
+      node.remove();
+    }
+
+    function handleWindowControl(node, action) {
+      if (action === 'close') {
+        closeWindow(node);
+      } else if (action === 'maximize') {
+        node.classList.toggle('is-maximized');
+        if (node.classList.contains('is-maximized')) {
+          node.dataset.prevLeft = node.style.left;
+          node.dataset.prevTop = node.style.top;
+          node.dataset.prevWidth = node.style.width;
+          node.dataset.prevHeight = node.style.height;
+          node.style.left = '4vw';
+          node.style.top = '80px';
+          node.style.width = '92vw';
+          node.style.height = 'calc(100vh - 120px)';
+        } else {
+          node.style.left = node.dataset.prevLeft;
+          node.style.top = node.dataset.prevTop;
+          node.style.width = node.dataset.prevWidth;
+          node.style.height = node.dataset.prevHeight;
+        }
+      } else if (action === 'minimize') {
+        node.style.display = 'none';
+        setTimeout(() => {
+          node.style.display = '';
+          focusWindow(node);
+        }, 1200);
+      }
+    }
+
+    function enableDrag(node) {
+      const header = node.querySelector('.window-header');
+      let startX = 0;
+      let startY = 0;
+      let offsetX = 0;
+      let offsetY = 0;
+      function onPointerDown(event) {
+        if (event.button !== 0) return;
+        startX = event.clientX;
+        startY = event.clientY;
+        const rect = node.getBoundingClientRect();
+        offsetX = startX - rect.left;
+        offsetY = startY - rect.top;
+        header.setPointerCapture(event.pointerId);
+        header.addEventListener('pointermove', onPointerMove);
+        header.addEventListener('pointerup', onPointerUp, { once: true });
+      }
+      function onPointerMove(event) {
+        const x = event.clientX - offsetX;
+        const y = event.clientY - offsetY;
+        node.style.left = `${x}px`;
+        node.style.top = `${y}px`;
+      }
+      function onPointerUp(event) {
+        header.releasePointerCapture(event.pointerId);
+        header.removeEventListener('pointermove', onPointerMove);
+      }
+      header.addEventListener('pointerdown', onPointerDown);
+    }
+
+    desktop.querySelectorAll('.icon').forEach(icon => {
+      icon.addEventListener('dblclick', () => openWindow(icon.dataset.app));
+      icon.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          openWindow(icon.dataset.app);
+        }
+      });
+      icon.addEventListener('click', () => openWindow(icon.dataset.app));
+    });
+
+    window.addEventListener('keydown', (event) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'n') {
+        event.preventDefault();
+        openWindow('notes');
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 't') {
+        event.preventDefault();
+        openWindow('terminal');
+      }
+      if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key.toLowerCase() === 'p') {
+        event.preventDefault();
+        toggleTheme();
+      }
+      if (event.key === 'Escape') {
+        const focused = windowLayer.querySelector('.window.is-focused');
+        if (focused) closeWindow(focused);
+      }
+    });
+
+    function toggleTheme() {
+      currentTheme = currentTheme === 'midnight' ? 'nova' : 'midnight';
+      if (currentTheme === 'nova') {
+        document.documentElement.style.setProperty('--desktop-bg', 'radial-gradient(circle at 15% 20%, rgba(255, 214, 102, 0.18), transparent 48%), radial-gradient(circle at 85% 12%, rgba(102, 170, 255, 0.2), transparent 55%), linear-gradient(145deg, #1b0536, #051e42)');
+        document.documentElement.style.setProperty('--accent', '#ffa94d');
+        document.documentElement.style.setProperty('--accent-soft', 'rgba(255, 169, 77, 0.28)');
+        document.documentElement.style.setProperty('--panel-light', '#3d1a5a');
+        themeStatus.textContent = 'Theme: Nova';
+        themeLabel.textContent = 'Nova';
+      } else {
+        document.documentElement.style.removeProperty('--desktop-bg');
+        document.documentElement.style.removeProperty('--accent');
+        document.documentElement.style.removeProperty('--accent-soft');
+        document.documentElement.style.removeProperty('--panel-light');
+        themeStatus.textContent = 'Theme: Midnight';
+        themeLabel.textContent = 'Midnight';
+      }
+      localStorage.setItem('orbit-theme', currentTheme);
+    }
+
+    if (currentTheme === 'nova') toggleTheme();
+
+    const menus = document.querySelectorAll('.menu-item');
+    const dropdowns = document.querySelectorAll('.dropdown');
+
+    function closeMenus() {
+      menus.forEach(btn => btn.setAttribute('aria-expanded', 'false'));
+      dropdowns.forEach(menu => menu.setAttribute('aria-hidden', 'true'));
+    }
+
+    menus.forEach(menuButton => {
+      menuButton.addEventListener('click', (event) => {
+        const id = menuButton.dataset.menu;
+        const menu = document.querySelector(`[data-dropdown="${id}"]`);
+        const isOpen = menuButton.getAttribute('aria-expanded') === 'true';
+        closeMenus();
+        if (!isOpen) {
+          menuButton.setAttribute('aria-expanded', 'true');
+          menu.setAttribute('aria-hidden', 'false');
+          const first = menu.querySelector('button, a');
+          first?.focus();
+        }
+        event.stopPropagation();
+      });
+      menuButton.addEventListener('keydown', (event) => {
+        if (event.key === 'ArrowDown') {
+          event.preventDefault();
+          menuButton.click();
+        }
+      });
+    });
+
+    dropdowns.forEach(menu => {
+      menu.addEventListener('keydown', (event) => {
+        const items = Array.from(menu.querySelectorAll('button, a'));
+        const index = items.indexOf(document.activeElement);
+        if (event.key === 'ArrowDown') {
+          event.preventDefault();
+          const next = items[(index + 1) % items.length];
+          next.focus();
+        }
+        if (event.key === 'ArrowUp') {
+          event.preventDefault();
+          const next = items[(index - 1 + items.length) % items.length];
+          next.focus();
+        }
+        if (event.key === 'Escape') {
+          closeMenus();
+          const trigger = document.querySelector(`.menu-item[data-menu="${menu.dataset.dropdown}"]`);
+          trigger?.focus();
+        }
+      });
+      menu.addEventListener('click', (event) => {
+        const target = event.target.closest('[data-launch], [data-action]');
+        if (!target) return;
+        if (target.dataset.launch) {
+          openWindow(target.dataset.launch);
+        } else if (target.dataset.action === 'toggle-theme') {
+          toggleTheme();
+        } else if (target.dataset.action === 'show-about') {
+          openWindow('about');
+        } else if (target.dataset.action === 'show-shortcuts') {
+          openWindow('shortcuts');
+        }
+        closeMenus();
+      });
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!event.target.closest('.menu-bar')) closeMenus();
+    });
+
+    windowLayer.addEventListener('click', (event) => {
+      const windowEl = event.target.closest('.window');
+      if (windowEl) focusWindow(windowEl);
+    });
+
+    // Auto-launch mission deck on boot for orientation
+    openWindow('mission');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new `mini2.html` standalone Orbit OS experience with inline styles and scripts
- implement draggable multi-window desktop with menu bar, apps, and theming
- include local storage notes, mission terminal simulation, and theme toggling controls

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d699279c34832aa332c63c7b1cf3da