### PR TITLE
Add atmospheric fog fade for terrain

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -1095,6 +1095,9 @@
   renderer.domElement.setAttribute('aria-label', 'Interactive terrain viewport');
 
   const scene = new THREE.Scene();
+  const fogColor = new THREE.Color(0x020817);
+  scene.fog = new THREE.Fog(fogColor, 380, 760);
+  renderer.setClearColor(fogColor);
   scene.add(new THREE.AmbientLight(0x666666));
   const sunLight = new THREE.DirectionalLight(0xffffff, 1.2);
   sunLight.position.set(260, 220, -500);


### PR DESCRIPTION
## Summary
- add a scene fog matching the sky color to softly fade distant terrain tiles
- align the renderer clear color with the fog backdrop for a seamless horizon

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68d69c7f5f24832a8238cac0433e58de