### PR TITLE
Rename Terrain console log and simplify loader spinner

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -119,45 +119,34 @@
       letter-spacing: 0.32em;
     }
     #loader .loader-logo {
-      --logo-tilt: 14deg;
-      --logo-spin-duration: 2.4s;
-      width: min(220px, 40vw);
+      width: min(140px, 30vw);
       aspect-ratio: 1 / 1;
-      perspective: 900px;
-      position: relative;
-      filter: drop-shadow(0 22px 32px rgba(0, 0, 0, 0.55));
-      contain: layout paint;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      filter: drop-shadow(0 18px 28px rgba(0, 0, 0, 0.45));
     }
-    #loader .loader-logo svg {
+    #loader .loader-spinner {
       width: 100%;
       height: 100%;
-      transform-style: preserve-3d;
-      backface-visibility: hidden;
-      will-change: transform;
-      transform: rotateX(var(--logo-tilt)) rotateY(0deg);
-      animation: logo-spin var(--logo-spin-duration) linear infinite;
-    }
-    #loader .loader-logo .logo-glow {
-      fill: url(#logo-gradient);
-      filter: drop-shadow(0 0 18px rgba(255, 139, 47, 0.65));
-    }
-    #loader .loader-logo .logo-frame {
-      fill: none;
-      stroke: rgba(255, 255, 255, 0.5);
-      stroke-width: 1.8;
+      border-radius: 50%;
+      border: 6px solid rgba(255, 255, 255, 0.18);
+      border-top-color: var(--accent-orange);
+      border-right-color: rgba(111, 208, 255, 0.75);
+      animation: loader-spin 1.1s linear infinite;
     }
     #loader .loader-meta {
       font-size: 0.38em;
       letter-spacing: 0.32em;
       color: rgba(255, 255, 255, 0.72);
     }
-    @keyframes logo-spin {
-      from { transform: rotateX(var(--logo-tilt)) rotateY(0deg); }
-      to { transform: rotateX(var(--logo-tilt)) rotateY(360deg); }
+    @keyframes loader-spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
     }
     @media (prefers-reduced-motion: reduce) {
-      #loader .loader-logo svg {
-        animation-duration: calc(var(--logo-spin-duration) * 2);
+      #loader .loader-spinner {
+        animation-duration: 2.2s;
       }
     }
     #loader #progress {
@@ -834,12 +823,12 @@
     <div class="hud-line"><span>Speed</span><span class="hud-value" data-hud="speed">0 m/s</span></div>
   </div>
   <div id="fps"></div>
-  <div id="console-dock">
+  <div id="console-dock" class="folded">
     <div class="console-headline">
-      <span class="console-title">Signal Log</span>
+      <span class="console-title">Console Log</span>
       <div class="console-actions">
-        <span id="console-status" class="console-status">Expanded</span>
-        <button id="console-fold-btn" type="button" aria-label="Collapse signal log" aria-expanded="true" aria-controls="console-log">
+        <span id="console-status" class="console-status">Folded</span>
+        <button id="console-fold-btn" type="button" aria-label="Expand console log" aria-expanded="false" aria-controls="console-log">
           <span class="fold-icon" aria-hidden="true">
             <svg viewBox="0 0 16 16" role="presentation" focusable="false">
               <path d="M4.2 2.8a1 1 0 0 1 1.6 0l4 5a1 1 0 0 1 0 1.2l-4 5a1 1 0 0 1-1.6-1.2L7.7 8 4.2 4a1 1 0 0 1 0-1.2z"></path>
@@ -854,21 +843,7 @@
     <div class="loader-content">
       <div class="loader-text">Loading <span id="progress">0%</span></div>
       <div class="loader-logo" aria-hidden="true">
-        <svg viewBox="0 0 120 120" role="presentation">
-          <defs>
-            <linearGradient id="logo-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-              <stop offset="0%" stop-color="#ff8b2f" />
-              <stop offset="55%" stop-color="#ffcf73" />
-              <stop offset="100%" stop-color="#6fd0ff" />
-            </linearGradient>
-          </defs>
-          <g>
-            <polygon class="logo-frame" points="60,6 108,34 108,86 60,114 12,86 12,34"></polygon>
-            <path class="logo-glow" d="M60 18L96 39V81L60 102L24 81V39L60 18ZM60 30L36 44V76L60 90L84 76V44L60 30Z"></path>
-            <circle cx="60" cy="60" r="16" fill="rgba(255,255,255,0.55)"></circle>
-            <path d="M60 42c9.9 0 18 8.1 18 18s-8.1 18-18 18-18-8.1-18-18 8.1-18 18-18zm0 6c-6.6 0-12 5.4-12 12s5.4 12 12 12 12-5.4 12-12-5.4-12-12-12z" fill="rgba(2,8,23,0.75)"></path>
-          </g>
-        </svg>
+        <div class="loader-spinner"></div>
       </div>
       <div class="loader-meta">© 2025 Cyborgs Dream</div>
     </div>
@@ -883,21 +858,21 @@
   const consoleStatus = document.getElementById('console-status');
 
   initConsoleLogs({ container: consoleLogEl, removeAfter: null });
-  console.log('Console dock expanded for extended diagnostics.');
+  console.log('Console dock folded for minimal footprint.');
 
   if (consoleFoldBtn && consoleDock) {
     const updateConsoleFold = (folded) => {
       if (consoleStatus) {
         consoleStatus.textContent = folded ? 'Folded' : 'Expanded';
       }
-      const label = folded ? 'Expand signal log' : 'Collapse signal log';
+      const label = folded ? 'Expand console log' : 'Collapse console log';
       consoleFoldBtn.setAttribute('aria-label', label);
     };
     consoleFoldBtn.addEventListener('click', () => {
       const isFolded = consoleDock.classList.toggle('folded');
       consoleFoldBtn.setAttribute('aria-expanded', String(!isFolded));
       updateConsoleFold(isFolded);
-      console.log(`Signal log ${isFolded ? 'folded' : 'expanded'}.`);
+      console.log(`Console log ${isFolded ? 'folded' : 'expanded'}.`);
     });
     updateConsoleFold(consoleDock.classList.contains('folded'));
   }


### PR DESCRIPTION
## Summary
- rename the Terrain diagnostics panel to "Console Log" and update accessibility labels
- start the console log folded by default for a cleaner initial layout
- replace the loader SVG with a simplified circular spinner animation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6ae25bc4c832aaf60f8e586513a0b