### PR TITLE
Simplify Terrain loader icon and refine sky rendering

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -93,14 +93,11 @@
     }
     #loader {
       position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
+      inset: 0;
       display: flex;
       align-items: center;
       justify-content: center;
-      background: rgba(2, 8, 23, 0.92);
+      background: radial-gradient(circle at 50% 40%, rgba(19, 45, 86, 0.65), rgba(2, 8, 23, 0.92));
       color: var(--text-white);
       font-family: 'Lucida Sans', 'Geneva', sans-serif;
       font-size: 2em;
@@ -111,85 +108,56 @@
     #loader .loader-content {
       display: grid;
       justify-items: center;
-      gap: 26px;
+      gap: 20px;
       text-align: center;
+      padding: 28px 32px;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      background: rgba(2, 8, 23, 0.65);
+      box-shadow: 0 28px 40px rgba(0, 0, 0, 0.45);
+      backdrop-filter: blur(12px);
     }
-    #loader .loader-text {
-      font-size: 0.58em;
-      letter-spacing: 0.32em;
-    }
-    #loader .loader-logo {
-      position: relative;
-      width: min(180px, 38vw);
+    #loader .loader-icon {
+      width: min(180px, 36vw);
       aspect-ratio: 1 / 1;
-      display: grid;
-      place-items: center;
-      padding: 22px;
-      border-radius: 28px;
-      background:
-        radial-gradient(circle at 30% 25%, rgba(255, 139, 47, 0.35), transparent 60%),
-        radial-gradient(circle at 70% 75%, rgba(111, 208, 255, 0.32), transparent 58%),
-        rgba(7, 17, 39, 0.85);
-      filter: drop-shadow(0 22px 36px rgba(0, 0, 0, 0.55));
-      overflow: hidden;
     }
-    #loader .loader-logo::before {
-      content: '';
-      position: absolute;
-      inset: 12px;
-      border-radius: 22px;
-      border: 1px solid rgba(255, 255, 255, 0.12);
-      background:
-        radial-gradient(circle, rgba(255, 255, 255, 0.05), transparent 65%),
-        radial-gradient(circle at 22% 18%, rgba(255, 139, 47, 0.25), transparent 55%),
-        radial-gradient(circle at 80% 70%, rgba(111, 208, 255, 0.25), transparent 60%),
-        rgba(2, 8, 23, 0.75);
-      pointer-events: none;
-      mix-blend-mode: screen;
-    }
-    #loader .loader-logo::after {
-      content: '';
-      position: absolute;
-      inset: 0;
-      border-radius: 28px;
-      background: radial-gradient(circle, rgba(255, 255, 255, 0.12), transparent 70%);
-      opacity: 0.35;
-      pointer-events: none;
-    }
-    #loader-canvas {
+    #loader .loader-icon svg {
       width: 100%;
       height: 100%;
-      border-radius: 18px;
-      position: relative;
-      z-index: 1;
-      background:
-        radial-gradient(circle at 40% 35%, rgba(255, 255, 255, 0.18), transparent 55%),
-        radial-gradient(circle at 70% 70%, rgba(111, 208, 255, 0.28), transparent 60%),
-        rgba(2, 8, 23, 0.9);
-      box-shadow: inset 0 0 40px rgba(255, 139, 47, 0.18), inset 0 0 70px rgba(111, 208, 255, 0.25);
+      fill: none;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      animation: loader-torus-spin 5s linear infinite;
+      transform-origin: 50% 50%;
+      filter: drop-shadow(0 0 12px rgba(111, 208, 255, 0.45));
     }
-    #loader .loader-halo {
-      position: absolute;
-      inset: 10%;
-      border-radius: 50%;
-      border: 2px solid rgba(255, 255, 255, 0.16);
-      box-shadow: 0 0 32px rgba(111, 208, 255, 0.35);
-      animation: loader-halo-shift 3.6s ease-in-out infinite;
-      pointer-events: none;
-      z-index: 0;
+    #loader .loader-icon .torus-base {
+      opacity: 0.55;
     }
-    @keyframes loader-halo-shift {
-      0%, 100% { transform: scale(0.92) rotate(0deg); opacity: 0.65; }
-      40% { transform: scale(1.05) rotate(8deg); opacity: 0.9; }
-      70% { transform: scale(1.08) rotate(-6deg); opacity: 0.75; }
+    #loader .loader-icon .torus-highlight {
+      animation: loader-torus-breathe 2.6s ease-in-out infinite;
+    }
+    @keyframes loader-torus-spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
+    @keyframes loader-torus-breathe {
+      0%, 100% { opacity: 0.35; }
+      50% { opacity: 0.9; }
+    }
+    #loader .loader-text {
+      font-size: 0.54em;
+      letter-spacing: 0.28em;
     }
     #loader .loader-meta {
-      font-size: 0.38em;
-      letter-spacing: 0.32em;
-      color: rgba(255, 255, 255, 0.72);
+      font-size: 0.36em;
+      letter-spacing: 0.3em;
+      color: rgba(255, 255, 255, 0.68);
     }
     @media (prefers-reduced-motion: reduce) {
-      #loader .loader-halo {
+      #loader .loader-icon svg {
+        animation-duration: 12s !important;
+      }
+      #loader .loader-icon .torus-highlight {
         animation-duration: 6s !important;
       }
     }
@@ -1000,11 +968,22 @@
   </div>
   <div id="loader">
     <div class="loader-content">
-      <div class="loader-text">Loading <span id="progress">0%</span></div>
-      <div class="loader-logo" aria-hidden="true">
-        <div class="loader-halo"></div>
-        <canvas id="loader-canvas" width="220" height="220" aria-hidden="true"></canvas>
+      <div class="loader-icon" aria-hidden="true">
+        <svg viewBox="0 0 120 120" role="presentation">
+          <g class="torus-base" stroke="#2f8dff" stroke-width="3">
+            <ellipse cx="60" cy="60" rx="44" ry="28"></ellipse>
+            <ellipse cx="60" cy="60" rx="30" ry="18"></ellipse>
+            <ellipse cx="60" cy="60" rx="44" ry="28" transform="rotate(55 60 60)"></ellipse>
+            <ellipse cx="60" cy="60" rx="30" ry="18" transform="rotate(-55 60 60)"></ellipse>
+          </g>
+          <g class="torus-highlight" stroke="#8fd6ff" stroke-width="2.2">
+            <ellipse cx="60" cy="60" rx="44" ry="28" transform="rotate(-28 60 60)"></ellipse>
+            <ellipse cx="60" cy="60" rx="30" ry="18" transform="rotate(28 60 60)"></ellipse>
+            <circle cx="60" cy="60" r="7"></circle>
+          </g>
+        </svg>
       </div>
+      <div class="loader-text">Loading <span id="progress">0%</span></div>
       <div class="loader-meta">© 2025 Cyborgs Dream</div>
     </div>
   </div>
@@ -1070,124 +1049,9 @@
     { label: '2160p', width: 3840, height: 2160 }
   ];
 
-  function initLoaderVisualizer(canvas) {
-    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
-    renderer.outputColorSpace = THREE.SRGBColorSpace;
-    renderer.setClearColor(0x000000, 0);
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
-    const scene = new THREE.Scene();
-    const camera = new THREE.PerspectiveCamera(32, 1, 0.1, 100);
-    camera.position.set(0, 0, 8.5);
-
-    const root = new THREE.Group();
-    scene.add(root);
-
-    const ringGeometry = new THREE.TorusGeometry(3.3, 0.32, 28, 160);
-    const ringMaterial = new THREE.MeshStandardMaterial({
-      color: 0x2d9dff,
-      emissive: 0x052238,
-      metalness: 0.45,
-      roughness: 0.28
-    });
-    const ring = new THREE.Mesh(ringGeometry, ringMaterial);
-    ring.rotation.x = Math.PI / 2;
-    root.add(ring);
-
-    const innerGeometry = new THREE.SphereGeometry(1.4, 28, 28);
-    const innerMaterial = new THREE.MeshStandardMaterial({
-      color: 0x0d2c4a,
-      emissive: 0x081a2d,
-      metalness: 0.1,
-      roughness: 0.6,
-      transparent: true,
-      opacity: 0.55
-    });
-    const inner = new THREE.Mesh(innerGeometry, innerMaterial);
-    root.add(inner);
-
-    const orbGeometry = new THREE.SphereGeometry(0.55, 32, 32);
-    const orbMaterial = new THREE.MeshStandardMaterial({
-      color: 0xff8b2f,
-      emissive: 0x311403,
-      metalness: 0.5,
-      roughness: 0.35
-    });
-    const orb = new THREE.Mesh(orbGeometry, orbMaterial);
-    root.add(orb);
-
-    const ambient = new THREE.AmbientLight(0x0d233b, 0.9);
-    scene.add(ambient);
-    const keyLight = new THREE.PointLight(0xffffff, 1.4, 0, 2);
-    keyLight.position.set(6, 6, 10);
-    scene.add(keyLight);
-    const rimLight = new THREE.PointLight(0x2d9dff, 1.1, 0, 2);
-    rimLight.position.set(-5, -4, -6);
-    scene.add(rimLight);
-
-    const clock = new THREE.Clock();
-    let rafId = null;
-    let running = true;
-
-    const resizeIfNeeded = () => {
-      const width = canvas.clientWidth;
-      const height = canvas.clientHeight;
-      if (width === 0 || height === 0) return;
-      const dpr = Math.min(window.devicePixelRatio || 1, 2);
-      if (canvas.width !== Math.round(width * dpr) || canvas.height !== Math.round(height * dpr)) {
-        renderer.setPixelRatio(dpr);
-        renderer.setSize(width, height, false);
-        camera.aspect = width / height;
-        camera.updateProjectionMatrix();
-      }
-    };
-
-    const render = () => {
-      if (!running) return;
-      rafId = requestAnimationFrame(render);
-      resizeIfNeeded();
-      const elapsed = clock.getElapsedTime();
-      root.rotation.y = elapsed * 0.9;
-      ring.rotation.z = elapsed * 0.35;
-      inner.rotation.y = elapsed * 1.1;
-      inner.rotation.x = Math.sin(elapsed * 0.8) * 0.35;
-      const orbitRadius = 3.3;
-      const orbitSpeed = 1.4;
-      orb.position.set(
-        Math.cos(elapsed * orbitSpeed) * orbitRadius,
-        Math.sin(elapsed * orbitSpeed * 0.75) * 0.8,
-        Math.sin(elapsed * orbitSpeed) * orbitRadius * 0.6
-      );
-      orb.rotation.y = elapsed * 2.2;
-      renderer.render(scene, camera);
-    };
-    render();
-
-    const handleResize = () => resizeIfNeeded();
-    window.addEventListener('resize', handleResize);
-
-    return () => {
-      running = false;
-      if (rafId) cancelAnimationFrame(rafId);
-      window.removeEventListener('resize', handleResize);
-      ringGeometry.dispose();
-      innerGeometry.dispose();
-      orbGeometry.dispose();
-      ringMaterial.dispose();
-      innerMaterial.dispose();
-      orbMaterial.dispose();
-      renderer.dispose();
-    };
-  }
-
-
   const loaderEl = document.getElementById('loader');
   const progressEl = document.getElementById('progress');
   function setProgress(p){ progressEl.textContent = Math.round(p) + '%'; }
-  const loaderCanvas = document.getElementById('loader-canvas');
-  let disposeLoaderVisual = () => {};
-  if (loaderCanvas) {
-    disposeLoaderVisual = initLoaderVisualizer(loaderCanvas);
-  }
 
   const fpsHolder = document.getElementById('fps');
 
@@ -1366,6 +1230,8 @@
     skyCanvas.height = 48;
     const ctx = skyCanvas.getContext('2d');
 
+    ctx.imageSmoothingEnabled = false;
+
     const palette = ['#23395d', '#2f4b7a', '#3f5f9d', '#6d8fce', '#9cc8ff'];
 
     ctx.fillStyle = palette[0];
@@ -1385,20 +1251,49 @@
       ctx.fillRect(0, y, skyCanvas.width, band.height);
     }
 
-    const cloudBlocks = [
-      { x: 6, y: 8, w: 18, h: 8, color: '#bad8ff' },
-      { x: 32, y: 12, w: 22, h: 10, color: '#cfe4ff' },
-      { x: 60, y: 6, w: 18, h: 8, color: '#b0d0ff' },
-      { x: 14, y: 20, w: 20, h: 9, color: '#d9ecff' },
-      { x: 48, y: 24, w: 24, h: 10, color: '#c4dcff' },
-      { x: 72, y: 18, w: 18, h: 8, color: '#d2e7ff' }
+    const toneSets = [
+      { stripes: ['#bcd8ff', '#cfe4ff', '#b3d2ff', '#cfe4ff'], highlight: '#e4f3ff', lowlight: '#97bff7' },
+      { stripes: ['#b2d0ff', '#bfd9ff', '#a8c7ff', '#bfd9ff'], highlight: '#dff0ff', lowlight: '#86aee8' },
+      { stripes: ['#c0dcff', '#d4e9ff', '#b9d5ff', '#d4e9ff'], highlight: '#f1f8ff', lowlight: '#8bb7f1' }
     ];
 
-    cloudBlocks.forEach(block => {
-      ctx.fillStyle = block.color;
-      ctx.fillRect(block.x, block.y, block.w, block.h);
-      ctx.fillStyle = 'rgba(255, 255, 255, 0.4)';
-      ctx.fillRect(block.x, block.y, Math.floor(block.w * 0.5), Math.ceil(block.h * 0.5));
+    function drawPixelCloud(x, y, width, height, tones) {
+      const px = 2;
+      const rows = Math.max(1, Math.floor(height / px));
+      const center = (rows - 1) / 2;
+      for (let row = 0; row < rows; row++) {
+        const taper = Math.round(Math.abs(row - center) * 1.1);
+        const rowWidth = Math.max(px * 3, width - taper * px);
+        const rowX = x + Math.floor((width - rowWidth) / 2);
+        const colorIndex = row % tones.stripes.length;
+        ctx.fillStyle = tones.stripes[colorIndex];
+        ctx.fillRect(rowX, y + row * px, rowWidth, px);
+      }
+
+      const highlightWidth = Math.max(px * 4, width - px * 4);
+      if (highlightWidth > px * 2) {
+        ctx.fillStyle = tones.highlight;
+        ctx.fillRect(x + Math.floor((width - highlightWidth) / 2), y + px, highlightWidth, px * 2);
+      }
+
+      const lowlightWidth = Math.max(px * 3, width - px * 5);
+      if (rows > 3 && lowlightWidth > px * 2) {
+        ctx.fillStyle = tones.lowlight;
+        ctx.fillRect(x + Math.floor((width - lowlightWidth) / 2), y + height - px * 3, lowlightWidth, px * 2);
+      }
+    }
+
+    const clouds = [
+      { x: 6, y: 8, w: 24, h: 12, tone: toneSets[0] },
+      { x: 34, y: 12, w: 28, h: 14, tone: toneSets[1] },
+      { x: 64, y: 6, w: 22, h: 12, tone: toneSets[2] },
+      { x: 14, y: 22, w: 26, h: 14, tone: toneSets[1] },
+      { x: 48, y: 26, w: 28, h: 14, tone: toneSets[0] },
+      { x: 78, y: 18, w: 20, h: 12, tone: toneSets[2] }
+    ];
+
+    clouds.forEach(cloud => {
+      drawPixelCloud(cloud.x, cloud.y, cloud.w, cloud.h, cloud.tone);
     });
 
     const texture = new THREE.CanvasTexture(skyCanvas);
@@ -1431,18 +1326,20 @@
   }
 
   const skyTexture = createSkyTexture();
-  const skyMaterial = new THREE.MeshBasicMaterial({ map: skyTexture, depthWrite: false, depthTest: false, transparent: true, opacity: 0.96 });
+  const skyMaterial = new THREE.MeshBasicMaterial({ map: skyTexture, depthWrite: false, transparent: true, opacity: 0.96 });
   const skyGeometry = new THREE.PlaneGeometry(2200, 900, 1, 1);
   const skyMesh = new THREE.Mesh(skyGeometry, skyMaterial);
   skyMesh.position.set(0, 160, -900);
+  skyMesh.renderOrder = -5;
   scene.add(skyMesh);
 
   const skyCeilingTexture = createSkyCeilingTexture();
-  const skyCeilingMaterial = new THREE.MeshBasicMaterial({ map: skyCeilingTexture, transparent: true, opacity: 0.85, side: THREE.DoubleSide, depthWrite: false, depthTest: false });
+  const skyCeilingMaterial = new THREE.MeshBasicMaterial({ map: skyCeilingTexture, transparent: true, opacity: 0.85, side: THREE.DoubleSide, depthWrite: false });
   const skyCeilingGeometry = new THREE.PlaneGeometry(2600, 2600, 1, 1);
   const skyCeiling = new THREE.Mesh(skyCeilingGeometry, skyCeilingMaterial);
   skyCeiling.rotation.x = -Math.PI / 2;
   skyCeiling.position.set(0, 420, 0);
+  skyCeiling.renderOrder = -6;
   scene.add(skyCeiling);
 
   const camera = new THREE.PerspectiveCamera(50, 16 / 9, 0.1, 3000);
@@ -1733,8 +1630,6 @@
       }
     }
     setProgress(100);
-    disposeLoaderVisual();
-    disposeLoaderVisual = () => {};
     if (loaderEl) loaderEl.remove();
     console.log(`Terrain populated with ${count} blocks.`);
   }


### PR DESCRIPTION
## Summary
- replace the Terrain loading overlay with a lightweight wireframe torus SVG and remove the old WebGL loader
- refresh loader styling for the new icon and keep motion-friendly fallbacks
- update the procedural sky texture with blocky pixel clouds and adjust sky meshes so they no longer cover the terrain

## Testing
- python3 -m http.server 8000 (manual visual check)


------
https://chatgpt.com/codex/tasks/task_e_68d712f913c0832a96ddec2897c17ee5