### PR TITLE
Refine terrain loader and sky dome

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -97,7 +97,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background: radial-gradient(circle at 50% 40%, rgba(19, 45, 86, 0.65), rgba(2, 8, 23, 0.92));
+      background: linear-gradient(180deg, #09132a 0%, #020817 100%);
       color: var(--text-white);
       font-family: 'Lucida Sans', 'Geneva', sans-serif;
       font-size: 2em;
@@ -137,11 +137,14 @@
       backface-visibility: hidden;
       filter: drop-shadow(0 0 12px rgba(111, 208, 255, 0.45));
     }
-    #loader .loader-icon .torus-base {
-      opacity: 0.55;
+    #loader .loader-icon .torus-body {
+      opacity: 0.95;
     }
     #loader .loader-icon .torus-highlight {
-      animation: loader-torus-breathe 2.6s ease-in-out infinite;
+      stroke-dasharray: 62 160;
+      stroke-dashoffset: 0;
+      animation: loader-torus-glide 3.2s ease-in-out infinite;
+      mix-blend-mode: screen;
     }
     @keyframes loader-torus-spin {
       0% { transform: rotateX(22deg) rotateY(0deg) rotateZ(0deg); }
@@ -150,9 +153,10 @@
       75% { transform: rotateX(-10deg) rotateY(270deg) rotateZ(135deg); }
       100% { transform: rotateX(22deg) rotateY(360deg) rotateZ(180deg); }
     }
-    @keyframes loader-torus-breathe {
-      0%, 100% { opacity: 0.35; }
-      50% { opacity: 0.9; }
+    @keyframes loader-torus-glide {
+      0% { stroke-dashoffset: 0; opacity: 0.35; }
+      50% { stroke-dashoffset: -80; opacity: 0.9; }
+      100% { stroke-dashoffset: -160; opacity: 0.35; }
     }
     #loader .loader-text {
       font-size: 0.54em;
@@ -168,7 +172,7 @@
         animation-duration: 12s !important;
       }
       #loader .loader-icon .torus-highlight {
-        animation-duration: 6s !important;
+        animation-duration: 7s !important;
       }
     }
     #loader #progress {
@@ -980,17 +984,35 @@
     <div class="loader-content">
       <div class="loader-icon" aria-hidden="true">
         <svg viewBox="0 0 120 120" role="presentation">
-          <g class="torus-base" stroke="#2f8dff" stroke-width="3">
-            <ellipse cx="60" cy="60" rx="44" ry="28"></ellipse>
-            <ellipse cx="60" cy="60" rx="30" ry="18"></ellipse>
-            <ellipse cx="60" cy="60" rx="44" ry="28" transform="rotate(55 60 60)"></ellipse>
-            <ellipse cx="60" cy="60" rx="30" ry="18" transform="rotate(-55 60 60)"></ellipse>
-          </g>
-          <g class="torus-highlight" stroke="#8fd6ff" stroke-width="2.2">
-            <ellipse cx="60" cy="60" rx="44" ry="28" transform="rotate(-28 60 60)"></ellipse>
-            <ellipse cx="60" cy="60" rx="30" ry="18" transform="rotate(28 60 60)"></ellipse>
-            <circle cx="60" cy="60" r="7"></circle>
-          </g>
+          <defs>
+            <radialGradient id="loaderTorusFill" cx="50%" cy="38%" r="60%">
+              <stop offset="0%" stop-color="#9ddcff" stop-opacity="0.9"></stop>
+              <stop offset="45%" stop-color="#3e84dd" stop-opacity="0.98"></stop>
+              <stop offset="100%" stop-color="#162f59" stop-opacity="1"></stop>
+            </radialGradient>
+            <linearGradient id="loaderTorusEdge" x1="20%" y1="0%" x2="80%" y2="100%">
+              <stop offset="0%" stop-color="#9bd6ff"></stop>
+              <stop offset="100%" stop-color="#2b5fa9"></stop>
+            </linearGradient>
+          </defs>
+          <path
+            class="torus-body"
+            fill="url(#loaderTorusFill)"
+            stroke="url(#loaderTorusEdge)"
+            stroke-width="3"
+            fill-rule="evenodd"
+            d="M60 16c24.3 0 44 19.7 44 44s-19.7 44-44 44S16 84.3 16 60 35.7 16 60 16zm0 20c-13.3 0-24 10.7-24 24s10.7 24 24 24 24-10.7 24-24S73.3 36 60 36z"
+          ></path>
+          <circle
+            class="torus-highlight"
+            cx="60"
+            cy="60"
+            r="34"
+            fill="none"
+            stroke="#d8f4ff"
+            stroke-width="5"
+            stroke-linecap="round"
+          ></circle>
         </svg>
       </div>
       <div class="loader-text">Loading <span id="progress">0%</span></div>
@@ -1234,106 +1256,54 @@
   const sunLightDesired = new THREE.Vector3();
   const sunLightTargetDesired = new THREE.Vector3();
 
-  function createSkyTexture(){
-    const skyCanvas = document.createElement('canvas');
-    skyCanvas.width = 96;
-    skyCanvas.height = 48;
-    const ctx = skyCanvas.getContext('2d');
+  function createSkyDomeMaterial() {
+    const uniforms = {
+      horizonColor: { value: new THREE.Color('#0f1d30') },
+      midColor: { value: new THREE.Color('#2e4f7d') },
+      zenithColor: { value: new THREE.Color('#79b5ff') },
+      glowColor: { value: new THREE.Color('#ffe6c2') },
+      glowStrength: { value: 0.12 },
+      time: { value: 0 }
+    };
 
-    ctx.imageSmoothingEnabled = false;
+    const material = new THREE.ShaderMaterial({
+      uniforms,
+      vertexShader: `
+        varying vec3 vWorldPosition;
+        void main() {
+          vec4 worldPosition = modelMatrix * vec4(position, 1.0);
+          vWorldPosition = worldPosition.xyz;
+          gl_Position = projectionMatrix * viewMatrix * worldPosition;
+        }
+      `,
+      fragmentShader: `
+        varying vec3 vWorldPosition;
+        uniform vec3 horizonColor;
+        uniform vec3 midColor;
+        uniform vec3 zenithColor;
+        uniform vec3 glowColor;
+        uniform float glowStrength;
+        uniform float time;
 
-    const palette = ['#23395d', '#2f4b7a', '#3f5f9d', '#6d8fce', '#9cc8ff'];
+        void main() {
+          vec3 worldDir = normalize(vWorldPosition);
+          float vertical = clamp(worldDir.y * 0.5 + 0.5, 0.0, 1.0);
+          float midBlend = smoothstep(0.15, 0.65, vertical);
+          vec3 base = mix(horizonColor, midColor, midBlend);
+          base = mix(base, zenithColor, smoothstep(0.45, 1.0, vertical));
 
-    ctx.fillStyle = palette[0];
-    ctx.fillRect(0, 0, skyCanvas.width, skyCanvas.height);
-
-    const bands = [
-      { color: palette[1], height: 12 },
-      { color: palette[2], height: 10 },
-      { color: palette[3], height: 10 },
-      { color: palette[4], height: 8 }
-    ];
-
-    let y = skyCanvas.height;
-    for (const band of bands) {
-      y -= band.height;
-      ctx.fillStyle = band.color;
-      ctx.fillRect(0, y, skyCanvas.width, band.height);
-    }
-
-    const toneSets = [
-      { stripes: ['#bcd8ff', '#cfe4ff', '#b3d2ff', '#cfe4ff'], highlight: '#e4f3ff', lowlight: '#97bff7' },
-      { stripes: ['#b2d0ff', '#bfd9ff', '#a8c7ff', '#bfd9ff'], highlight: '#dff0ff', lowlight: '#86aee8' },
-      { stripes: ['#c0dcff', '#d4e9ff', '#b9d5ff', '#d4e9ff'], highlight: '#f1f8ff', lowlight: '#8bb7f1' }
-    ];
-
-    function drawPixelCloud(x, y, width, height, tones) {
-      const px = 2;
-      const rows = Math.max(1, Math.floor(height / px));
-      const center = (rows - 1) / 2;
-      for (let row = 0; row < rows; row++) {
-        const taper = Math.round(Math.abs(row - center) * 1.1);
-        const rowWidth = Math.max(px * 3, width - taper * px);
-        const rowX = x + Math.floor((width - rowWidth) / 2);
-        const colorIndex = row % tones.stripes.length;
-        ctx.fillStyle = tones.stripes[colorIndex];
-        ctx.fillRect(rowX, y + row * px, rowWidth, px);
-      }
-
-      const highlightWidth = Math.max(px * 4, width - px * 4);
-      if (highlightWidth > px * 2) {
-        ctx.fillStyle = tones.highlight;
-        ctx.fillRect(x + Math.floor((width - highlightWidth) / 2), y + px, highlightWidth, px * 2);
-      }
-
-      const lowlightWidth = Math.max(px * 3, width - px * 5);
-      if (rows > 3 && lowlightWidth > px * 2) {
-        ctx.fillStyle = tones.lowlight;
-        ctx.fillRect(x + Math.floor((width - lowlightWidth) / 2), y + height - px * 3, lowlightWidth, px * 2);
-      }
-    }
-
-    const clouds = [
-      { x: 6, y: 8, w: 24, h: 12, tone: toneSets[0] },
-      { x: 34, y: 12, w: 28, h: 14, tone: toneSets[1] },
-      { x: 64, y: 6, w: 22, h: 12, tone: toneSets[2] },
-      { x: 14, y: 22, w: 26, h: 14, tone: toneSets[1] },
-      { x: 48, y: 26, w: 28, h: 14, tone: toneSets[0] },
-      { x: 78, y: 18, w: 20, h: 12, tone: toneSets[2] }
-    ];
-
-    clouds.forEach(cloud => {
-      drawPixelCloud(cloud.x, cloud.y, cloud.w, cloud.h, cloud.tone);
+          float glow = pow(1.0 - vertical, 1.8);
+          float pulse = 0.65 + 0.35 * sin(time * 0.12);
+          vec3 color = base + glow * glowStrength * pulse * glowColor;
+          gl_FragColor = vec4(clamp(color, 0.0, 1.0), 1.0);
+        }
+      `,
+      side: THREE.BackSide,
+      depthWrite: false,
+      fog: false
     });
 
-    const texture = new THREE.CanvasTexture(skyCanvas);
-    texture.generateMipmaps = false;
-    texture.magFilter = THREE.NearestFilter;
-    texture.minFilter = THREE.NearestFilter;
-    texture.wrapS = THREE.ClampToEdgeWrapping;
-    texture.wrapT = THREE.ClampToEdgeWrapping;
-    return texture;
-  }
-
-  function createSkyCeilingTexture() {
-    const canvas = document.createElement('canvas');
-    canvas.width = 128;
-    canvas.height = 128;
-    const ctx = canvas.getContext('2d');
-    const gradient = ctx.createRadialGradient(64, 64, 12, 64, 64, 70);
-    gradient.addColorStop(0, 'rgba(156, 200, 255, 0.55)');
-    gradient.addColorStop(0.45, 'rgba(82, 126, 190, 0.7)');
-    gradient.addColorStop(1, 'rgba(24, 46, 82, 0.9)');
-    ctx.fillStyle = gradient;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.center.set(0.5, 0.5);
-    texture.generateMipmaps = false;
-    texture.magFilter = THREE.LinearFilter;
-    texture.minFilter = THREE.LinearFilter;
-    texture.wrapS = THREE.ClampToEdgeWrapping;
-    texture.wrapT = THREE.ClampToEdgeWrapping;
-    return texture;
+    return { material, uniforms };
   }
 
   function createCloudTexture() {
@@ -1417,22 +1387,11 @@
     return texture;
   }
 
-  const skyTexture = createSkyTexture();
-  const skyMaterial = new THREE.MeshBasicMaterial({ map: skyTexture, depthWrite: false, transparent: true, opacity: 0.96 });
-  const skyGeometry = new THREE.PlaneGeometry(2200, 900, 1, 1);
-  const skyMesh = new THREE.Mesh(skyGeometry, skyMaterial);
-  skyMesh.position.set(0, 160, -900);
-  skyMesh.renderOrder = -5;
-  scene.add(skyMesh);
-
-  const skyCeilingTexture = createSkyCeilingTexture();
-  const skyCeilingMaterial = new THREE.MeshBasicMaterial({ map: skyCeilingTexture, transparent: true, opacity: 0.85, side: THREE.DoubleSide, depthWrite: false });
-  const skyCeilingGeometry = new THREE.PlaneGeometry(2600, 2600, 1, 1);
-  const skyCeiling = new THREE.Mesh(skyCeilingGeometry, skyCeilingMaterial);
-  skyCeiling.rotation.x = -Math.PI / 2;
-  skyCeiling.position.set(0, 420, 0);
-  skyCeiling.renderOrder = -6;
-  scene.add(skyCeiling);
+  const { material: skyMaterial, uniforms: skyUniforms } = createSkyDomeMaterial();
+  const skyGeometry = new THREE.SphereGeometry(4200, 48, 24);
+  const skyDome = new THREE.Mesh(skyGeometry, skyMaterial);
+  skyDome.renderOrder = -6;
+  scene.add(skyDome);
 
   const cloudTexture = createCloudTexture();
   const cloudSprites = [];
@@ -1488,7 +1447,6 @@
   const horizontalForward = new THREE.Vector3();
   const moveVector = new THREE.Vector3();
   const lookVector = new THREE.Vector3();
-  const skyTarget = new THREE.Vector3();
   window.addEventListener('keydown', e => {
     if (['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(e.key)) { keyState[e.key] = true; e.preventDefault(); }
   });
@@ -1790,19 +1748,10 @@
   }
 
   function updateSky(time, dt){
-    const skyDistance = 1600;
-    skyTarget.copy(camera.position).addScaledVector(lookVector, skyDistance);
-    skyTarget.y = camera.position.y + 120;
-    skyMesh.position.lerp(skyTarget, 0.08);
-    skyMesh.lookAt(camera.position.x, camera.position.y + 40, camera.position.z);
-
-    const desiredHeight = camera.position.y + 320;
-    skyCeiling.position.x = camera.position.x;
-    skyCeiling.position.z = camera.position.z;
-    skyCeiling.position.y = THREE.MathUtils.damp(skyCeiling.position.y, desiredHeight, 4.2, dt);
-    skyCeiling.rotation.z = Math.sin(time * 0.18) * 0.08;
-    const ceilingOpacity = 0.7 + (Math.sin(time * 0.35) + 1) * 0.12;
-    skyCeilingMaterial.opacity = THREE.MathUtils.damp(skyCeilingMaterial.opacity, ceilingOpacity, 2.5, dt);
+    skyDome.position.copy(camera.position);
+    const glowTarget = 0.12 + (Math.sin(time * 0.22) + 1) * 0.04;
+    skyUniforms.glowStrength.value = THREE.MathUtils.damp(skyUniforms.glowStrength.value, glowTarget, 2.4, dt);
+    skyUniforms.time.value = time;
 
     for (const sprite of cloudSprites) {
       const data = sprite.userData;


### PR DESCRIPTION
## Summary
- make the loading overlay fully opaque and replace the spinner with a simple torus design
- swap the sky planes for a shader-driven dome that follows the camera for a seamless horizon

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d79dc34b8c832a89479dd8449f2e1b