### PR TITLE
Add black hole vista to terrain horizon

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -1387,6 +1387,121 @@
     return texture;
   }
 
+  function createBlackHoleCoreTexture() {
+    const size = 512;
+    const canvas = document.createElement('canvas');
+    canvas.width = canvas.height = size;
+    const ctx = canvas.getContext('2d');
+
+    const gradient = ctx.createRadialGradient(size / 2, size / 2, size * 0.12, size / 2, size / 2, size * 0.5);
+    gradient.addColorStop(0, 'rgba(0, 0, 0, 1)');
+    gradient.addColorStop(0.32, 'rgba(2, 4, 10, 1)');
+    gradient.addColorStop(0.5, 'rgba(18, 12, 28, 0.95)');
+    gradient.addColorStop(0.7, 'rgba(22, 14, 40, 0.8)');
+    gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, size, size);
+
+    for (let i = 0; i < 28; i++) {
+      const radius = size * (0.2 + i * 0.01 + Math.random() * 0.015);
+      ctx.beginPath();
+      ctx.arc(size / 2, size / 2, radius, 0, Math.PI * 2);
+      const opacity = 0.32 - i * 0.008;
+      ctx.strokeStyle = `rgba(122, 72, 160, ${Math.max(0, opacity)})`;
+      ctx.lineWidth = 2 + i * 0.5;
+      ctx.stroke();
+    }
+
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.center.set(0.5, 0.5);
+    texture.generateMipmaps = false;
+    texture.magFilter = THREE.LinearFilter;
+    texture.minFilter = THREE.LinearFilter;
+    texture.wrapS = THREE.ClampToEdgeWrapping;
+    texture.wrapT = THREE.ClampToEdgeWrapping;
+    texture.needsUpdate = true;
+    return texture;
+  }
+
+  function createBlackHoleHaloTexture() {
+    const size = 512;
+    const canvas = document.createElement('canvas');
+    canvas.width = canvas.height = size;
+    const ctx = canvas.getContext('2d');
+
+    const gradient = ctx.createRadialGradient(size / 2, size / 2, size * 0.18, size / 2, size / 2, size * 0.5);
+    gradient.addColorStop(0, 'rgba(0, 0, 0, 0)');
+    gradient.addColorStop(0.35, 'rgba(120, 90, 255, 0.08)');
+    gradient.addColorStop(0.55, 'rgba(180, 120, 255, 0.35)');
+    gradient.addColorStop(0.78, 'rgba(255, 170, 120, 0.28)');
+    gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, size, size);
+
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.center.set(0.5, 0.5);
+    texture.generateMipmaps = false;
+    texture.magFilter = THREE.LinearFilter;
+    texture.minFilter = THREE.LinearFilter;
+    texture.wrapS = THREE.ClampToEdgeWrapping;
+    texture.wrapT = THREE.ClampToEdgeWrapping;
+    texture.needsUpdate = true;
+    return texture;
+  }
+
+  function createAccretionDiskTexture() {
+    const size = 1024;
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d');
+
+    ctx.translate(size / 2, size / 2);
+    ctx.rotate(-Math.PI / 8);
+
+    const radialGradient = ctx.createRadialGradient(0, 0, size * 0.12, 0, 0, size * 0.48);
+    radialGradient.addColorStop(0, 'rgba(0, 0, 0, 0)');
+    radialGradient.addColorStop(0.35, 'rgba(80, 30, 120, 0.6)');
+    radialGradient.addColorStop(0.55, 'rgba(190, 90, 255, 0.55)');
+    radialGradient.addColorStop(0.75, 'rgba(255, 180, 120, 0.4)');
+    radialGradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
+    ctx.fillStyle = radialGradient;
+    ctx.fillRect(-size / 2, -size / 2, size, size);
+
+    const arcCount = 26;
+    ctx.lineWidth = 8;
+    ctx.strokeStyle = 'rgba(255, 220, 180, 0.28)';
+    for (let i = 0; i < arcCount; i++) {
+      const radius = size * (0.18 + i * 0.009 + Math.random() * 0.004);
+      const start = Math.random() * Math.PI * 2;
+      const length = Math.PI * (0.45 + Math.random() * 0.25);
+      ctx.globalAlpha = 0.3 + Math.random() * 0.4;
+      ctx.beginPath();
+      ctx.arc(0, 0, radius, start, start + length);
+      ctx.stroke();
+    }
+
+    const innerGlow = ctx.createRadialGradient(0, 0, size * 0.08, 0, 0, size * 0.28);
+    innerGlow.addColorStop(0, 'rgba(255, 255, 255, 0.45)');
+    innerGlow.addColorStop(0.6, 'rgba(255, 150, 120, 0.08)');
+    innerGlow.addColorStop(1, 'rgba(0, 0, 0, 0)');
+    ctx.globalAlpha = 1;
+    ctx.fillStyle = innerGlow;
+    ctx.beginPath();
+    ctx.arc(0, 0, size * 0.35, 0, Math.PI * 2);
+    ctx.fill();
+
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.center.set(0.5, 0.5);
+    texture.generateMipmaps = false;
+    texture.magFilter = THREE.LinearFilter;
+    texture.minFilter = THREE.LinearFilter;
+    texture.wrapS = THREE.ClampToEdgeWrapping;
+    texture.wrapT = THREE.ClampToEdgeWrapping;
+    texture.needsUpdate = true;
+    return texture;
+  }
+
   const { material: skyMaterial, uniforms: skyUniforms } = createSkyDomeMaterial();
   const skyGeometry = new THREE.SphereGeometry(4200, 48, 24);
   const skyDome = new THREE.Mesh(skyGeometry, skyMaterial);
@@ -1424,6 +1539,58 @@
     cloudSprites.push(sprite);
   }
   scene.add(cloudGroup);
+
+  const blackHoleTextures = {
+    core: createBlackHoleCoreTexture(),
+    halo: createBlackHoleHaloTexture(),
+    disk: createAccretionDiskTexture()
+  };
+
+  const blackHoleGroup = new THREE.Group();
+  blackHoleGroup.renderOrder = -5;
+  scene.add(blackHoleGroup);
+
+  const blackHoleCore = new THREE.Sprite(new THREE.SpriteMaterial({
+    map: blackHoleTextures.core,
+    transparent: true,
+    depthWrite: false,
+    depthTest: false
+  }));
+  blackHoleCore.scale.set(640, 640, 1);
+  blackHoleGroup.add(blackHoleCore);
+
+  const blackHoleHalo = new THREE.Sprite(new THREE.SpriteMaterial({
+    map: blackHoleTextures.halo,
+    transparent: true,
+    depthWrite: false,
+    depthTest: false,
+    blending: THREE.AdditiveBlending,
+    opacity: 0.68
+  }));
+  blackHoleHalo.scale.set(980, 980, 1);
+  blackHoleGroup.add(blackHoleHalo);
+
+  const blackHoleDisk = new THREE.Sprite(new THREE.SpriteMaterial({
+    map: blackHoleTextures.disk,
+    transparent: true,
+    depthWrite: false,
+    depthTest: true,
+    blending: THREE.AdditiveBlending,
+    opacity: 0.82
+  }));
+  blackHoleDisk.scale.set(1380, 820, 1);
+  blackHoleDisk.material.rotation = Math.PI / 10;
+  blackHoleGroup.add(blackHoleDisk);
+
+  const blackHoleState = {
+    group: blackHoleGroup,
+    core: blackHoleCore,
+    halo: blackHoleHalo,
+    disk: blackHoleDisk,
+    offset: new THREE.Vector3(-420, 110, -980),
+    target: new THREE.Vector3()
+  };
+  blackHoleGroup.position.copy(blackHoleState.offset);
 
   const camera = new THREE.PerspectiveCamera(50, 16 / 9, 0.1, 3000);
   const controls = {
@@ -1752,6 +1919,25 @@
     const glowTarget = 0.12 + (Math.sin(time * 0.22) + 1) * 0.04;
     skyUniforms.glowStrength.value = THREE.MathUtils.damp(skyUniforms.glowStrength.value, glowTarget, 2.4, dt);
     skyUniforms.time.value = time;
+
+    if (blackHoleState) {
+      blackHoleState.target.copy(camera.position).add(blackHoleState.offset);
+      blackHoleState.target.y = camera.position.y * 0.42 + 48;
+      blackHoleState.group.position.lerp(blackHoleState.target, THREE.MathUtils.clamp(dt * 1.4, 0, 1));
+
+      const haloTarget = 0.6 + Math.sin(time * 0.52) * 0.18;
+      const dampedHalo = THREE.MathUtils.damp(blackHoleState.halo.material.opacity, haloTarget, 2.2, dt);
+      blackHoleState.halo.material.opacity = THREE.MathUtils.clamp(dampedHalo, 0.32, 0.9);
+
+      blackHoleState.disk.material.rotation += dt * 0.22;
+      blackHoleState.halo.material.rotation -= dt * 0.08;
+
+      const corePulse = 620 + Math.sin(time * 0.9) * 28;
+      blackHoleState.core.scale.set(corePulse, corePulse, 1);
+      const diskWidth = 1380 + Math.sin(time * 0.4) * 64;
+      const diskHeight = 820 + Math.cos(time * 0.55) * 44;
+      blackHoleState.disk.scale.set(diskWidth, diskHeight, 1);
+    }
 
     for (const sprite of cloudSprites) {
       const data = sprite.userData;


### PR DESCRIPTION
## Summary
- add canvas-generated textures for a black hole core, halo, and accretion disk
- place an animated black hole sprite group on the horizon that trails the camera
- drive black hole pulses and rotation from the existing sky update loop

## Testing
- not run (visual change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7a711df04832a8fd8294017a6a371