### PR TITLE
Add ZX Spectrum rendering mode with color clash post-process

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -957,6 +957,7 @@
     <div class="hud-render-modes" role="group" aria-label="Rendering mode">
       <button type="button" class="render-mode-btn is-active" data-render-mode="default">Default</button>
       <button type="button" class="render-mode-btn" data-render-mode="wire">Wired Vectors</button>
+      <button type="button" class="render-mode-btn" data-render-mode="zx">ZX Spectrum</button>
     </div>
     <div class="hud-line"><span>Position</span><span class="hud-value" data-hud="position">0, 0, 0</span></div>
     <div class="hud-line"><span>Heading</span><span class="hud-value" data-hud="heading">0° / 0°</span></div>
@@ -1063,7 +1064,8 @@
   const renderModeButtons = document.querySelectorAll('[data-render-mode]');
   const renderModeDescriptions = {
     default: 'default shading',
-    wire: 'wired vectors'
+    wire: 'wired vectors',
+    zx: 'ZX Spectrum palette'
   };
   let currentRenderMode = 'default';
   const wireTerrainColor = new THREE.Color(0x8fd6ff);
@@ -1242,6 +1244,8 @@
   renderer.domElement.style.touchAction = 'none';
   renderer.domElement.tabIndex = 0;
   renderer.domElement.setAttribute('aria-label', 'Interactive terrain viewport');
+
+  const zxEffect = createZxEffect(renderer);
 
   const scene = new THREE.Scene();
   const fogColor = new THREE.Color(0x020817);
@@ -1500,6 +1504,251 @@
     texture.wrapT = THREE.ClampToEdgeWrapping;
     texture.needsUpdate = true;
     return texture;
+  }
+
+  function createZxEffect(renderer) {
+    const paletteHex = [
+      0x000000, 0x0000aa, 0xaa0000, 0xaa00aa,
+      0x00aa00, 0x00aaaa, 0xaaaa00, 0xaaaaaa,
+      0x000000, 0x0000ff, 0xff0000, 0xff00ff,
+      0x00ff00, 0x00ffff, 0xffff00, 0xffffff
+    ];
+    const paletteVectors = paletteHex.map(hex => {
+      const color = new THREE.Color(hex);
+      return new THREE.Vector3(color.r, color.g, color.b);
+    });
+
+    const resolution = new THREE.Vector2(1, 1);
+    const blockCount = new THREE.Vector2(1, 1);
+
+    const sceneTarget = new THREE.WebGLRenderTarget(16, 16, {
+      minFilter: THREE.LinearFilter,
+      magFilter: THREE.LinearFilter,
+      depthBuffer: true,
+      stencilBuffer: false
+    });
+    sceneTarget.texture.generateMipmaps = false;
+    if ('colorSpace' in sceneTarget.texture && renderer.outputColorSpace) {
+      sceneTarget.texture.colorSpace = renderer.outputColorSpace;
+    } else if ('encoding' in sceneTarget.texture && renderer.outputEncoding !== undefined) {
+      sceneTarget.texture.encoding = renderer.outputEncoding;
+    }
+
+    const attributeTarget = new THREE.WebGLRenderTarget(2, 2, {
+      minFilter: THREE.NearestFilter,
+      magFilter: THREE.NearestFilter,
+      depthBuffer: false,
+      stencilBuffer: false,
+      type: THREE.UnsignedByteType
+    });
+    attributeTarget.texture.generateMipmaps = false;
+
+    const quadGeometry = new THREE.PlaneGeometry(2, 2);
+    const orthoCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+
+    const fullscreenVertexShader = `
+      varying vec2 vUv;
+      void main() {
+        vUv = uv;
+        gl_Position = vec4(position.xy, 0.0, 1.0);
+      }
+    `;
+
+    const attributeUniforms = {
+      sceneTexture: { value: null },
+      resolution: { value: resolution },
+      blockCount: { value: blockCount },
+      palette: { value: paletteVectors }
+    };
+
+    const attributeMaterial = new THREE.ShaderMaterial({
+      uniforms: attributeUniforms,
+      vertexShader: fullscreenVertexShader,
+      fragmentShader: `
+        precision highp float;
+        uniform sampler2D sceneTexture;
+        uniform vec2 resolution;
+        uniform vec2 blockCount;
+        uniform vec3 palette[16];
+        varying vec2 vUv;
+
+        const float BLOCK_SIZE = 8.0;
+        const float SAMPLE_GRID = 4.0;
+
+        float colorDistance(vec3 a, vec3 b) {
+          vec3 d = a - b;
+          return dot(d, d);
+        }
+
+        int nearestPaletteIndex(vec3 color) {
+          float bestDistance = 1e9;
+          int bestIndex = 0;
+          for (int i = 0; i < 16; i++) {
+            vec3 paletteColor = palette[i];
+            float dist = colorDistance(color, paletteColor);
+            if (dist < bestDistance) {
+              bestDistance = dist;
+              bestIndex = i;
+            }
+          }
+          return bestIndex;
+        }
+
+        vec2 clampUv(vec2 pixel) {
+          vec2 clamped = clamp(pixel, vec2(0.0), resolution - vec2(1.0));
+          return (clamped + 0.5) / resolution;
+        }
+
+        void main() {
+          vec2 blockIndex = floor(vUv * blockCount);
+          vec2 blockBase = blockIndex * BLOCK_SIZE;
+          float sampleStep = BLOCK_SIZE / SAMPLE_GRID;
+          vec3 averageColor = vec3(0.0);
+          float totalSamples = SAMPLE_GRID * SAMPLE_GRID;
+
+          for (int y = 0; y < 4; y++) {
+            for (int x = 0; x < 4; x++) {
+              vec2 offset = (vec2(float(x), float(y)) + 0.5) * sampleStep;
+              vec2 samplePixel = blockBase + offset;
+              vec2 sampleUv = clampUv(samplePixel);
+              averageColor += texture2D(sceneTexture, sampleUv).rgb;
+            }
+          }
+          averageColor /= totalSamples;
+
+          int paperIndex = nearestPaletteIndex(averageColor);
+          vec3 paperColor = palette[paperIndex];
+
+          float maxDistance = -1.0;
+          vec3 furthestColor = paperColor;
+
+          for (int y = 0; y < 4; y++) {
+            for (int x = 0; x < 4; x++) {
+              vec2 offset = (vec2(float(x), float(y)) + 0.5) * sampleStep;
+              vec2 samplePixel = blockBase + offset;
+              vec2 sampleUv = clampUv(samplePixel);
+              vec3 sampleColor = texture2D(sceneTexture, sampleUv).rgb;
+              float dist = colorDistance(sampleColor, paperColor);
+              if (dist > maxDistance) {
+                maxDistance = dist;
+                furthestColor = sampleColor;
+              }
+            }
+          }
+
+          int inkIndex = nearestPaletteIndex(furthestColor);
+          if (maxDistance < 0.003) {
+            inkIndex = paperIndex;
+          }
+
+          gl_FragColor = vec4(float(paperIndex) / 255.0, float(inkIndex) / 255.0, 0.0, 1.0);
+        }
+      `,
+      depthTest: false,
+      depthWrite: false,
+      transparent: false,
+      blending: THREE.NoBlending
+    });
+
+    const attributeScene = new THREE.Scene();
+    attributeScene.add(new THREE.Mesh(quadGeometry, attributeMaterial));
+
+    const finalUniforms = {
+      sceneTexture: { value: null },
+      attributeTexture: { value: null },
+      resolution: { value: resolution },
+      blockCount: { value: blockCount },
+      palette: { value: paletteVectors }
+    };
+
+    const finalMaterial = new THREE.ShaderMaterial({
+      uniforms: finalUniforms,
+      vertexShader: fullscreenVertexShader,
+      fragmentShader: `
+        precision highp float;
+        uniform sampler2D sceneTexture;
+        uniform sampler2D attributeTexture;
+        uniform vec2 resolution;
+        uniform vec2 blockCount;
+        uniform vec3 palette[16];
+        varying vec2 vUv;
+
+        float colorDistance(vec3 a, vec3 b) {
+          vec3 d = a - b;
+          return dot(d, d);
+        }
+
+        int decodeIndex(float value) {
+          return clamp(int(floor(value * 255.0 + 0.5)), 0, 15);
+        }
+
+        vec3 paletteColor(int index) {
+          return palette[index];
+        }
+
+        void main() {
+          vec2 pixelCoord = vUv * resolution;
+          vec2 blockCoord = floor(pixelCoord / 8.0);
+          blockCoord = clamp(blockCoord, vec2(0.0), blockCount - vec2(1.0));
+          vec2 attributeUv = (blockCoord + 0.5) / blockCount;
+
+          vec4 attributeData = texture2D(attributeTexture, attributeUv);
+          int paperIndex = decodeIndex(attributeData.r);
+          int inkIndex = decodeIndex(attributeData.g);
+          vec3 paperColor = paletteColor(paperIndex);
+          vec3 inkColor = paletteColor(inkIndex);
+
+          vec3 sceneColor = texture2D(sceneTexture, vUv).rgb;
+          float paperDist = colorDistance(sceneColor, paperColor);
+          float inkDist = colorDistance(sceneColor, inkColor);
+          vec3 finalColor = paperColor;
+
+          if (inkIndex != paperIndex && inkDist < paperDist) {
+            finalColor = inkColor;
+          }
+
+          gl_FragColor = vec4(finalColor, 1.0);
+        }
+      `,
+      depthTest: false,
+      depthWrite: false,
+      transparent: false,
+      blending: THREE.NoBlending
+    });
+
+    const finalScene = new THREE.Scene();
+    finalScene.add(new THREE.Mesh(quadGeometry.clone(), finalMaterial));
+
+    return {
+      enabled: false,
+      setEnabled(value) {
+        this.enabled = Boolean(value);
+      },
+      setSize(width, height) {
+        const safeWidth = Math.max(1, Math.floor(width));
+        const safeHeight = Math.max(1, Math.floor(height));
+        sceneTarget.setSize(safeWidth, safeHeight);
+        const blockWidth = Math.max(1, Math.floor(safeWidth / 8));
+        const blockHeight = Math.max(1, Math.floor(safeHeight / 8));
+        attributeTarget.setSize(blockWidth, blockHeight);
+        resolution.set(safeWidth, safeHeight);
+        blockCount.set(blockWidth, blockHeight);
+      },
+      render(scene, camera) {
+        renderer.setRenderTarget(sceneTarget);
+        renderer.render(scene, camera);
+
+        attributeUniforms.sceneTexture.value = sceneTarget.texture;
+        renderer.setRenderTarget(attributeTarget);
+        renderer.render(attributeScene, orthoCamera);
+
+        finalUniforms.sceneTexture.value = sceneTarget.texture;
+        finalUniforms.attributeTexture.value = attributeTarget.texture;
+
+        renderer.setRenderTarget(null);
+        renderer.render(finalScene, orthoCamera);
+      }
+    };
   }
 
   const { material: skyMaterial, uniforms: skyUniforms } = createSkyDomeMaterial();
@@ -1972,6 +2221,7 @@
     const previousMode = currentRenderMode;
     currentRenderMode = mode;
     const isWire = mode === 'wire';
+    const isZx = mode === 'zx';
     if (defaultTerrainColor) {
       terrainMesh.material.wireframe = isWire;
       terrainMesh.material.color.copy(isWire ? wireTerrainColor : defaultTerrainColor);
@@ -1987,6 +2237,7 @@
       block.material.needsUpdate = true;
     });
     updateCityRenderMode(isWire);
+    zxEffect.setEnabled(isZx);
     updateRenderButtons(mode);
     if (announce && previousMode !== mode) {
       const description = renderModeDescriptions[mode] || mode;
@@ -2217,7 +2468,11 @@
     updateBlocks(dt, now / 1000);
     updateSky(now / 1000, dt);
     updateLighting(dt, now / 1000, isCameraMoving);
-    renderer.render(scene, camera);
+    if (zxEffect.enabled) {
+      zxEffect.render(scene, camera);
+    } else {
+      renderer.render(scene, camera);
+    }
     fpsMonitor.end();
     requestAnimationFrame(animate);
   }
@@ -2352,6 +2607,7 @@
     renderer.setSize(res.width, res.height, false);
     renderer.domElement.width = res.width;
     renderer.domElement.height = res.height;
+    zxEffect.setSize(res.width, res.height);
     camera.aspect = res.width / res.height;
     camera.updateProjectionMatrix();
     resolutionDisplay.textContent = `${res.label} — ${res.width} × ${res.height}`;


### PR DESCRIPTION
## Summary
- add a ZX Spectrum option to the terrain HUD render mode controls
- implement a ZX Spectrum post-processing pipeline that enforces 8×8 colour clash with the classic palette
- hook the new effect into the render loop and resolution handling so it can be toggled dynamically

## Testing
- python3 -m http.server 8000 (manual verification in browser)


------
https://chatgpt.com/codex/tasks/task_e_68d7fc0314f0832a97ca1a7126bf9006