### PR TITLE
Add ScanX PDF importer and DX workflow integration

### DIFF
--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -84,6 +84,10 @@
         {
           "label": "Docu Monster Studio Pro",
           "type": "document-editor"
+        },
+        {
+          "label": "ScanX Analyzer",
+          "type": "scanx"
         }
       ]
     },
@@ -143,6 +147,11 @@
         "type": "document-editor",
         "emoji": "📄",
         "label": "Docu Monster Studio Pro"
+      },
+      {
+        "type": "scanx",
+        "emoji": "🖨️",
+        "label": "ScanX"
       },
       {
         "type": "calculator",
@@ -261,6 +270,12 @@
       "content": "<iframe src=\"documonster.html\" style=\"width:100%;height:100%;border:none;background:#c0c0c0;\"></iframe>",
       "width": 1280,
       "height": 900
+    },
+    "scanx": {
+      "title": "ScanX Reconstruction Lab",
+      "content": "<iframe src=\"scanx.html\" style=\"width:100%;height:100%;border:none;background:#f4f6ff;\"></iframe>",
+      "width": 900,
+      "height": 640
     },
     "cloud-storage": {
       "title": "Cloud Storage",

--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -646,6 +646,9 @@
         let appData = null;
         let persistWindows = true;
         let windowStates = JSON.parse(localStorage.getItem('windowStates') || '{}');
+        const DOCUMONSTER_STORAGE_KEY = 'documonster-studiopro-autosave-v0-1';
+        const docuBridge = { frameWindow: null, ready: false, queue: [], lastWindowId: null };
+        const scanxFrames = new Set();
 
         function setTheme(theme) {
             const link = document.getElementById('theme-link');
@@ -736,7 +739,7 @@
                 link.href = `app-js/${safe}.js`;
                 document.head.appendChild(link);
             });
-            ['html-studio.html', 'cloud-storage.html', 'documonster.html'].forEach(p => {
+            ['html-studio.html', 'cloud-storage.html', 'documonster.html', 'scanx.html'].forEach(p => {
                 const l = document.createElement('link');
                 l.rel = 'prefetch';
                 l.href = p;
@@ -868,8 +871,26 @@
                 const loader = document.createElement('div');
                 loader.className = 'loading-overlay';
                 loader.textContent = 'Loading...';
-                winEl.querySelector('.window-content').appendChild(loader);
-                iframe.addEventListener('load', () => loader.remove());
+                const contentEl = winEl.querySelector('.window-content');
+                contentEl.appendChild(loader);
+                iframe.addEventListener('load', () => {
+                    loader.remove();
+                    if (type === 'document-editor') {
+                        docuBridge.frameWindow = iframe.contentWindow;
+                        docuBridge.ready = false;
+                    }
+                    if (type === 'scanx') {
+                        scanxFrames.add(iframe.contentWindow);
+                    }
+                });
+                if (type === 'document-editor') {
+                    docuBridge.frameWindow = iframe.contentWindow;
+                    docuBridge.ready = false;
+                    docuBridge.lastWindowId = id;
+                }
+                if (type === 'scanx') {
+                    scanxFrames.add(iframe.contentWindow);
+                }
             }
             if (type === 'console-log') {
                 // lazily load console log handler and keep restore callback
@@ -906,10 +927,135 @@
                 .replace(/\{CALENDAR_DAYS\}/g, calDays);
             return { title: cfg.title, content, width: cfg.width, height: cfg.height };
         }
+
+        function getDocuMonsterIframe() {
+            return document.querySelector('.window[data-window-type="document-editor"] iframe');
+        }
+
+        function ensureDocuMonsterWindow() {
+            const existingFrame = getDocuMonsterIframe();
+            if (existingFrame && existingFrame.contentWindow) {
+                docuBridge.frameWindow = existingFrame.contentWindow;
+                const hostWindow = existingFrame.closest('.window');
+                if (hostWindow) {
+                    hostWindow.style.display = 'flex';
+                    hostWindow.style.zIndex = ++state.zIndex;
+                }
+                return docuBridge.frameWindow;
+            }
+            const newId = openWindow('document-editor');
+            if (!newId) return null;
+            docuBridge.lastWindowId = newId;
+            const winEl = document.getElementById(newId);
+            const frame = winEl ? winEl.querySelector('iframe') : null;
+            if (frame && frame.contentWindow) {
+                docuBridge.frameWindow = frame.contentWindow;
+            }
+            return frame ? frame.contentWindow : null;
+        }
+
+        function flushDocuMonsterQueue() {
+            if (!docuBridge.ready || !docuBridge.frameWindow) return;
+            while (docuBridge.queue.length) {
+                const factory = docuBridge.queue.shift();
+                if (typeof factory !== 'function') continue;
+                try {
+                    docuBridge.frameWindow.postMessage(factory(), '*');
+                } catch (err) {
+                    console.error('Failed to deliver message to Docu Monster', err);
+                }
+            }
+        }
+
+        function sendToDocuMonster(factory) {
+            const target = ensureDocuMonsterWindow();
+            if (!target) return;
+            if (docuBridge.ready) {
+                try {
+                    target.postMessage(factory(), '*');
+                } catch (err) {
+                    console.error('Docu Monster communication error', err);
+                }
+            } else {
+                docuBridge.queue.push(factory);
+            }
+        }
+
+        function handleScanxDocument(payload) {
+            if (!payload || !payload.document) return;
+            try {
+                localStorage.setItem(DOCUMONSTER_STORAGE_KEY, JSON.stringify(payload.document));
+            } catch (err) {
+                console.warn('Unable to persist ScanX document', err);
+            }
+            const statusBar = document.getElementById('status-bar');
+            if (statusBar) {
+                statusBar.textContent = `ScanX prepared ${payload.name || 'a document'} for Docu Monster…`;
+            }
+            sendToDocuMonster(() => ({
+                type: 'documonster:load-document',
+                payload: {
+                    document: payload.document,
+                    meta: {
+                        source: 'ScanX',
+                        name: payload.name || 'scanx-import.dx',
+                        status: 'ScanX document loaded.',
+                        transient: false,
+                        persistToStorage: true
+                    }
+                }
+            }));
+        }
+
+        window.addEventListener('message', (event) => {
+            const data = event.data;
+            if (!data || typeof data !== 'object') return;
+            if (data.type === 'documonster:ready') {
+                if (event.source) {
+                    docuBridge.frameWindow = event.source;
+                }
+                docuBridge.ready = true;
+                flushDocuMonsterQueue();
+            } else if (data.type === 'documonster:document-loaded') {
+                if (data.payload && data.payload.source === 'ScanX') {
+                    scanxFrames.forEach(frame => {
+                        try {
+                            frame.postMessage({ type: 'scanx:documonster-confirm', payload: data.payload }, '*');
+                        } catch (err) {
+                            console.warn('Failed to notify ScanX frame', err);
+                        }
+                    });
+                    const statusBar = document.getElementById('status-bar');
+                    if (statusBar) {
+                        const name = data.payload.name || 'the document';
+                        const pages = data.payload.pageCount != null ? data.payload.pageCount : '?';
+                        statusBar.textContent = `Docu Monster opened ${name} from ScanX (${pages} pages).`;
+                    }
+                }
+            } else if (data.type === 'scanx:open-document') {
+                if (event.source) {
+                    scanxFrames.add(event.source);
+                }
+                handleScanxDocument(data.payload || {});
+            }
+        });
         
        function closeWindow(id) {
            const window = document.getElementById(id);
             if (!window) return;
+            const type = window.dataset.windowType;
+            if (type === 'document-editor') {
+                docuBridge.ready = false;
+                docuBridge.frameWindow = null;
+                docuBridge.lastWindowId = null;
+                docuBridge.queue.length = 0;
+            }
+            if (type === 'scanx') {
+                const frame = window.querySelector('iframe');
+                if (frame && frame.contentWindow) {
+                    scanxFrames.delete(frame.contentWindow);
+                }
+            }
             // run cleanup for special windows such as console log
             if (window._restoreConsole) {
                 window._restoreConsole();

--- a/apps/app1/app-js/scanx.js
+++ b/apps/app1/app-js/scanx.js
@@ -1,0 +1,2 @@
+// Launch ScanX within an Orbit OS window
+WinAPI.createWindow('scanx');

--- a/apps/app1/documonster.html
+++ b/apps/app1/documonster.html
@@ -563,7 +563,7 @@
       </div>
     </div>
   </div>
-  <input type="file" id="openFileInput" accept="application/json" hidden />
+  <input type="file" id="openFileInput" accept=".dx,.DX,.json,application/json" hidden />
 
 <script>
 (function(){
@@ -669,6 +669,9 @@
   const FRAME_STYLES = ['standard','outline','shadow','banner'];
   const COLUMN_STYLE_CLASSES = COLUMN_STYLES.filter(v=>v!=='standard').map(v=>'style-'+v);
   const FRAME_STYLE_CLASSES = FRAME_STYLES.filter(v=>v!=='standard').map(v=>'style-'+v);
+  const DX_MIME = 'application/vnd.orbit-documonster+json';
+  const DX_EXTENSION = '.dx';
+  const ACCEPTED_EXTENSIONS = ['.dx', '.json'];
   const ELEMENT_STYLE_OPTIONS = {
     columns:[
       { value:'standard', label:'Standard Body' },
@@ -1288,7 +1291,7 @@
     try{
       localStorage.setItem(STORAGE_KEY, JSON.stringify(docModel));
       markDirty(false);
-      setStatus('Saved to local storage.');
+      setStatus('Saved to local storage (.dx autosave).');
     }catch(err){
       console.error('Save failed', err);
       setStatus('Save failed: '+err.message, false);
@@ -2693,6 +2696,60 @@
     openTemplateChooser();
   }
 
+  function getFileExtension(name){
+    if(typeof name !== 'string') return '';
+    const idx = name.lastIndexOf('.');
+    return idx >= 0 ? name.slice(idx).toLowerCase() : '';
+  }
+
+  function suggestDownloadName(){
+    const base = (docModel && (docModel.codename || docModel.docName)) || 'documonster';
+    const slug = base.toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/(^-|-$)/g,'') || 'documonster';
+    const timestamp = new Date().toISOString().replace(/[:T]/g,'-').split('.')[0];
+    return `${slug}-${timestamp}`;
+  }
+
+  function applyLoadedDocument(data, meta = {}){
+    let normalized;
+    try{
+      normalized = normalizeDocument(data);
+    }catch(err){
+      console.error('Invalid document payload', err);
+      setStatus('Failed to load document: '+err.message, false);
+      return false;
+    }
+    docModel = normalized;
+    markDirty(false);
+    updateVersionInfo();
+    renderDocument();
+    snapTo(0, true);
+    if(meta.persistToStorage){
+      try{
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(docModel));
+      }catch(err){
+        console.warn('Autosave write failed', err);
+      }
+    }
+    const statusMessage = meta.status || (meta.source ? meta.source+' document loaded.' : 'Document loaded.');
+    const transient = meta.hasOwnProperty('transient') ? !!meta.transient : false;
+    setStatus(statusMessage, transient);
+    if(window.parent && window.parent !== window){
+      window.parent.postMessage({ type:'documonster:document-loaded', payload:{ source: meta.source || 'external', name: meta.name || '', pageCount: getTotalPages() } }, '*');
+    }
+    return true;
+  }
+
+  function handleExternalDocumentLoad(payload){
+    if(!payload || typeof payload !== 'object') return;
+    const meta = Object.assign({ source:'External', transient:false }, payload.meta || {});
+    if(payload.meta && Object.prototype.hasOwnProperty.call(payload.meta, 'persistToStorage')){
+      meta.persistToStorage = !!payload.meta.persistToStorage;
+    }
+    meta.name = meta.name || (payload.meta && payload.meta.name) || '';
+    meta.status = meta.status || meta.note || (meta.source ? `Received document from ${meta.source}.` : 'Document received.');
+    applyLoadedDocument(payload.document, meta);
+  }
+
   function openDocumentFile(){
     openFileInput.value = '';
     openFileInput.click();
@@ -2701,23 +2758,39 @@
   openFileInput.addEventListener('change', ()=>{
     const file = openFileInput.files && openFileInput.files[0];
     if(!file) return;
+    const ext = getFileExtension(file.name);
+    if(ext && !ACCEPTED_EXTENSIONS.includes(ext)){
+      setStatus('Unsupported file type. Please choose a .dx document.', false);
+      return;
+    }
     const reader = new FileReader();
     reader.onload = ()=>{
+      let data;
       try{
-        const data = JSON.parse(reader.result);
-        docModel = normalizeDocument(data);
-        markDirty(false);
-        updateVersionInfo();
-        renderDocument();
-        snapTo(0, true);
-        setStatus('Document loaded.');
+        data = JSON.parse(reader.result);
       }catch(err){
-        console.error(err);
-        setStatus('Failed to open file: '+err.message, false);
+        console.error('Failed to parse document', err);
+        setStatus('Invalid document file: '+err.message, false);
+        return;
       }
+      applyLoadedDocument(data, { source:'File', name:file.name, status:'Loaded '+file.name, transient:false });
     };
     reader.readAsText(file);
   });
+
+  window.addEventListener('message', event=>{
+    const data = event.data;
+    if(!data || typeof data !== 'object') return;
+    if(data.type === 'documonster:load-document'){
+      handleExternalDocumentLoad(data.payload || {});
+    }
+  });
+
+  function notifyParentReady(){
+    if(window.parent && window.parent !== window){
+      window.parent.postMessage({ type:'documonster:ready' }, '*');
+    }
+  }
 
   function loadAutosave(){
     const saved = loadFromStorage();
@@ -2734,16 +2807,16 @@
   }
 
   function saveAsDocument(){
-    const blob = new Blob([JSON.stringify(docModel, null, 2)], { type:'application/json' });
+    const blob = new Blob([JSON.stringify(docModel, null, 2)], { type:DX_MIME });
     const a = document.createElement('a');
     a.href = URL.createObjectURL(blob);
-    a.download = 'documonster-protodesk-'+Date.now()+'.json';
+    a.download = `${suggestDownloadName()}${DX_EXTENSION}`;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(a.href);
     markDirty(false);
-    setStatus('JSON downloaded.');
+    setStatus('DX file downloaded.');
   }
 
   function openMenu(id, anchor){
@@ -2997,6 +3070,7 @@
   updateVersionInfo();
   snapTo(0, true);
   setStatus('Ready.', false);
+  notifyParentReady();
   window.addEventListener('resize', ()=>{
     buildThumbnails();
     applyZoom();

--- a/apps/app1/scanx.html
+++ b/apps/app1/scanx.html
@@ -1,0 +1,425 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ScanX • Orbit OS</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg:#f4f6ff;
+      --panel:#ffffff;
+      --ink:#13224d;
+      --muted:#5c678a;
+      --accent:#3c7dff;
+      --border:#c7d4f5;
+      --success:#1e7e34;
+      --error:#b71c1c;
+    }
+    * { box-sizing:border-box; }
+    body {
+      margin:0;
+      font-family:"Segoe UI", system-ui, sans-serif;
+      background:var(--bg);
+      color:var(--ink);
+      min-height:100vh;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding:24px;
+    }
+    .scanx-shell {
+      width:100%;
+      max-width:960px;
+      background:var(--panel);
+      border:2px solid var(--border);
+      border-radius:16px;
+      box-shadow:0 18px 48px rgba(19,34,77,0.18);
+      padding:28px;
+      display:flex;
+      flex-direction:column;
+      gap:24px;
+    }
+    header h1 {
+      margin:0;
+      font-size:28px;
+      letter-spacing:0.04em;
+    }
+    header p {
+      margin:6px 0 0 0;
+      color:var(--muted);
+      font-size:15px;
+    }
+    .upload-row {
+      display:flex;
+      flex-wrap:wrap;
+      gap:12px;
+      align-items:center;
+    }
+    .upload-row input[type="file"] {
+      flex:1 1 260px;
+      padding:10px;
+      border:1px dashed var(--border);
+      border-radius:10px;
+      background:#f9fbff;
+    }
+    button {
+      font:600 15px "Segoe UI", system-ui, sans-serif;
+      border-radius:10px;
+      border:1px solid transparent;
+      padding:10px 18px;
+      cursor:pointer;
+      transition:transform 0.15s ease, box-shadow 0.15s ease, opacity 0.2s ease;
+      background:linear-gradient(145deg, var(--accent), #1d4bd8);
+      color:#fff;
+      box-shadow:0 8px 20px rgba(60,125,255,0.24);
+      min-width:150px;
+    }
+    button:disabled {
+      opacity:0.55;
+      cursor:not-allowed;
+      box-shadow:none;
+      transform:none;
+    }
+    button.secondary {
+      background:#fff;
+      color:var(--ink);
+      border-color:var(--border);
+      box-shadow:0 4px 12px rgba(19,34,77,0.08);
+    }
+    .actions {
+      display:flex;
+      flex-wrap:wrap;
+      gap:12px;
+    }
+    .status {
+      padding:14px 16px;
+      border-radius:12px;
+      background:#eef3ff;
+      border:1px solid var(--border);
+      font-size:15px;
+      line-height:1.5;
+    }
+    .status.success {
+      background:rgba(30,126,52,0.12);
+      border-color:rgba(30,126,52,0.4);
+      color:var(--success);
+    }
+    .status.error {
+      background:rgba(183,28,28,0.12);
+      border-color:rgba(183,28,28,0.4);
+      color:var(--error);
+    }
+    .status.processing {
+      background:rgba(60,125,255,0.12);
+      border-color:rgba(60,125,255,0.4);
+    }
+    .summary {
+      display:grid;
+      grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
+      gap:16px;
+    }
+    .page-card {
+      border:1px solid var(--border);
+      border-radius:12px;
+      padding:14px 16px;
+      background:#f9fbff;
+      box-shadow:0 4px 14px rgba(19,34,77,0.08);
+    }
+    .page-card h3 {
+      margin:0 0 8px 0;
+      font-size:18px;
+    }
+    .page-card p {
+      margin:0;
+      color:var(--muted);
+      font-size:14px;
+      line-height:1.5;
+    }
+    .meta-row {
+      display:flex;
+      flex-wrap:wrap;
+      gap:12px;
+      font-size:14px;
+      color:var(--muted);
+    }
+    @media (max-width:640px) {
+      body { padding:12px; }
+      .scanx-shell { padding:20px; }
+      button { flex:1 1 100%; min-width:0; }
+      .upload-row input[type="file"] { flex:1 1 100%; }
+    }
+  </style>
+</head>
+<body>
+  <main class="scanx-shell">
+    <header>
+      <h1>ScanX Reconstruction Lab</h1>
+      <p>Transform source PDFs into clean Docu Monster layouts with one click.</p>
+    </header>
+    <section class="upload-row">
+      <input type="file" id="pdfInput" accept="application/pdf" />
+      <button id="analyzeBtn" disabled>Analyze PDF</button>
+    </section>
+    <section class="meta-row" id="metaRow" hidden>
+      <span id="metaFile"></span>
+      <span id="metaPages"></span>
+    </section>
+    <section class="status" id="statusPanel">Select a PDF to begin.</section>
+    <section class="actions">
+      <button id="downloadBtn" class="secondary" disabled>Download .dx</button>
+      <button id="saveLocalBtn" class="secondary" disabled>Save to Local Storage</button>
+      <button id="openDocBtn" disabled>Open in Docu Monster</button>
+    </section>
+    <section class="summary" id="summary"></section>
+  </main>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.min.js" integrity="sha512-5jEvhczHxVn9Yx8RJWb1x1oGf4bm/FYnGV8eK3opgDdGztqKqRR3YKHyCuXapnwYfJOLLmObEWj1vDLteA94Xw==" crossorigin="anonymous"></script>
+  <script>
+    const STORAGE_KEY = 'documonster-studiopro-autosave-v0-1';
+    const DX_MIME = 'application/vnd.orbit-documonster+json';
+    const DX_EXTENSION = '.dx';
+
+    const pdfInput = document.getElementById('pdfInput');
+    const analyzeBtn = document.getElementById('analyzeBtn');
+    const statusPanel = document.getElementById('statusPanel');
+    const downloadBtn = document.getElementById('downloadBtn');
+    const saveLocalBtn = document.getElementById('saveLocalBtn');
+    const openDocBtn = document.getElementById('openDocBtn');
+    const summaryEl = document.getElementById('summary');
+    const metaRow = document.getElementById('metaRow');
+    const metaFile = document.getElementById('metaFile');
+    const metaPages = document.getElementById('metaPages');
+
+    let working = false;
+    let currentDoc = null;
+    let currentFileName = '';
+
+    if (window.pdfjsLib) {
+      pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.worker.min.js';
+    }
+
+    function setStatus(message, mode = 'info') {
+      statusPanel.textContent = message;
+      statusPanel.classList.remove('success', 'error', 'processing');
+      if (mode === 'success') statusPanel.classList.add('success');
+      else if (mode === 'error') statusPanel.classList.add('error');
+      else if (mode === 'processing') statusPanel.classList.add('processing');
+    }
+
+    function toggleWorking(state) {
+      working = state;
+      analyzeBtn.disabled = state || !pdfInput.files.length;
+      downloadBtn.disabled = state || !currentDoc;
+      saveLocalBtn.disabled = state || !currentDoc;
+      openDocBtn.disabled = state || !currentDoc;
+      pdfInput.disabled = state;
+      if (state) {
+        setStatus('Analyzing PDF… this may take a moment.', 'processing');
+      }
+    }
+
+    function escapeHtml(input) {
+      return input.replace(/[&<>"']/g, ch => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+      })[ch]);
+    }
+
+    function textItemsToParagraphs(items) {
+      const buffer = [];
+      let currentLine = '';
+      items.forEach(item => {
+        const chunk = item.str || '';
+        if (!chunk.trim()) {
+          currentLine += chunk;
+        } else {
+          currentLine += (currentLine.endsWith(' ') ? '' : (currentLine ? ' ' : '')) + chunk;
+        }
+        if (item.hasEOL) {
+          buffer.push(currentLine.trim());
+          currentLine = '';
+        }
+      });
+      if (currentLine.trim()) buffer.push(currentLine.trim());
+      const normalized = buffer.join('\n');
+      return normalized.split(/\n{2,}/).map(p => p.replace(/\s+/g, ' ').trim()).filter(Boolean);
+    }
+
+    function paragraphsToHtml(paragraphs, pageIndex) {
+      if (!paragraphs.length) {
+        return `<p>ScanX imported page ${pageIndex + 1}. Add your layout flair here.</p>`;
+      }
+      return paragraphs.map(p => `<p>${escapeHtml(p)}</p>`).join('');
+    }
+
+    function paragraphsToPreview(paragraphs) {
+      if (!paragraphs.length) return 'No textual content detected.';
+      const combined = paragraphs.join(' ');
+      return combined.length > 220 ? combined.slice(0, 220) + '…' : combined;
+    }
+
+    function buildDocument(pages, sourceName) {
+      const timestamp = new Date();
+      return {
+        version: '1.0.0',
+        docVersion: '1.0.0',
+        codename: 'ScanX Reconstruction',
+        docName: 'Docu Monster Studio Pro',
+        releaseNotes: [
+          `Generated by ScanX from ${sourceName} on ${timestamp.toLocaleString()}.`,
+          'Each page has been recreated as a single-column article ready for refinement.'
+        ],
+        pages
+      };
+    }
+
+    async function analyzePdf(file) {
+      if (!window.pdfjsLib) {
+        setStatus('PDF.js failed to load. Please reload the window.', 'error');
+        return;
+      }
+      toggleWorking(true);
+      summaryEl.innerHTML = '';
+      metaRow.hidden = true;
+      try {
+        const arrayBuffer = await file.arrayBuffer();
+        const loadingTask = pdfjsLib.getDocument({ data: arrayBuffer });
+        const pdf = await loadingTask.promise;
+        const pages = [];
+        const summaries = [];
+        for (let pageIndex = 1; pageIndex <= pdf.numPages; pageIndex++) {
+          const page = await pdf.getPage(pageIndex);
+          const textContent = await page.getTextContent();
+          const paragraphs = textItemsToParagraphs(textContent.items || []);
+          const html = paragraphsToHtml(paragraphs, pageIndex - 1);
+          pages.push({
+            title: `ScanX Page ${pageIndex}`,
+            subtitle: '',
+            deck: '',
+            theme: 'standard',
+            elements: [{
+              type: 'columns',
+              columns: 1,
+              windows: [html],
+              windowLayout: [{ width: null, height: null }],
+              style: 'standard',
+              html
+            }],
+            footerLeft: 'Docu Monster Studio Pro',
+            footerRight: 'Page {{page}} of {{total}}'
+          });
+          summaries.push({
+            index: pageIndex,
+            preview: paragraphsToPreview(paragraphs)
+          });
+        }
+        currentDoc = buildDocument(pages, file.name);
+        currentFileName = file.name;
+        renderSummary(summaries);
+        metaFile.textContent = `Source: ${file.name}`;
+        metaPages.textContent = `Pages detected: ${pages.length}`;
+        metaRow.hidden = false;
+        setStatus(`Scan complete. ${pages.length} page${pages.length === 1 ? '' : 's'} ready for Docu Monster.`, 'success');
+      } catch (err) {
+        console.error('ScanX failed', err);
+        currentDoc = null;
+        setStatus('ScanX could not analyze this PDF: ' + (err.message || err), 'error');
+      } finally {
+        toggleWorking(false);
+      }
+    }
+
+    function renderSummary(entries) {
+      summaryEl.innerHTML = entries.map(entry => `
+        <article class="page-card">
+          <h3>Page ${entry.index}</h3>
+          <p>${escapeHtml(entry.preview)}</p>
+        </article>
+      `).join('');
+    }
+
+    function makeFileBaseName() {
+      const base = currentFileName ? currentFileName.replace(/\.[^.]+$/, '') : 'scanx-output';
+      return base.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '') || 'scanx-output';
+    }
+
+    function downloadDx() {
+      if (!currentDoc) return;
+      const blob = new Blob([JSON.stringify(currentDoc, null, 2)], { type: DX_MIME });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = `${makeFileBaseName()}${DX_EXTENSION}`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(a.href);
+      setStatus('DX file downloaded to your disk.', 'success');
+    }
+
+    function saveToLocalStorage() {
+      if (!currentDoc) return;
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(currentDoc));
+        setStatus('Document stored in local Orbit OS storage for Docu Monster.', 'success');
+      } catch (err) {
+        console.error('Local save failed', err);
+        setStatus('Unable to write to local storage: ' + (err.message || err), 'error');
+      }
+    }
+
+    function openInDocuMonster() {
+      if (!currentDoc) return;
+      setStatus('Sending document to Docu Monster…', 'processing');
+      try {
+        window.parent?.postMessage({
+          type: 'scanx:open-document',
+          payload: {
+            document: currentDoc,
+            name: `${makeFileBaseName()}${DX_EXTENSION}`
+          }
+        }, '*');
+      } catch (err) {
+        console.error('Bridge failed', err);
+        setStatus('Could not notify Docu Monster: ' + (err.message || err), 'error');
+      }
+    }
+
+    pdfInput.addEventListener('change', () => {
+      currentDoc = null;
+      summaryEl.innerHTML = '';
+      metaRow.hidden = true;
+      downloadBtn.disabled = true;
+      saveLocalBtn.disabled = true;
+      openDocBtn.disabled = true;
+      if (pdfInput.files.length) {
+        analyzeBtn.disabled = false;
+        setStatus('Ready to scan. Click “Analyze PDF” to continue.');
+      } else {
+        analyzeBtn.disabled = true;
+        setStatus('Select a PDF to begin.');
+      }
+    });
+
+    analyzeBtn.addEventListener('click', () => {
+      const file = pdfInput.files[0];
+      if (!file || working) return;
+      analyzePdf(file);
+    });
+
+    downloadBtn.addEventListener('click', downloadDx);
+    saveLocalBtn.addEventListener('click', saveToLocalStorage);
+    openDocBtn.addEventListener('click', openInDocuMonster);
+
+    window.addEventListener('message', (event) => {
+      const data = event.data;
+      if (!data || typeof data !== 'object') return;
+      if (data.type === 'scanx:documonster-confirm') {
+        setStatus(`Docu Monster opened ${data.payload?.name || 'the document'} (${data.payload?.pageCount ?? '?'} pages).`, 'success');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/docs/docu-monster-file-format.md
+++ b/docs/docu-monster-file-format.md
@@ -5,7 +5,8 @@ This document defines the JSON structure used by Docu Monster Studio Pro for sav
 ## 1. File container
 
 * **MIME type:** `application/json`
-* **Recommended extension:** `.json`
+* **Recommended extension:** `.dx`
+* **Legacy extension:** `.json` files remain compatible for backward interoperability.
 * **Root value:** a single JSON object referred to as the *document model*.
 * **Character encoding:** UTF-8.
 


### PR DESCRIPTION
## Summary
- add the ScanX workspace that rebuilds uploaded PDFs into Docu Monster documents and exports them as `.dx`
- connect ScanX with Docu Monster through new OS menu/icons, local storage sharing, and window messaging
- teach Docu Monster about the `.dx` format and refresh the public file-format guidance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d93bd71f98832aa0b402687f404e30