### PR TITLE
Fix task bar closing logic and cinematic loader

### DIFF
--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -269,10 +269,131 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            background: rgba(255, 255, 255, 0.7);
-            color: #000;
-            font-size: 18px;
+            background: radial-gradient(circle at 20% 20%, rgba(10, 25, 60, 0.88), rgba(0, 0, 0, 0.92));
+            color: #fff;
             z-index: 5;
+            perspective: 1000px;
+            backdrop-filter: blur(8px);
+        }
+
+        .loading-overlay .loading-scene {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 24px;
+            transform-style: preserve-3d;
+            animation: loading-float 4.5s ease-in-out infinite;
+        }
+
+        .loading-overlay .loading-orbit {
+            position: relative;
+            width: 140px;
+            height: 140px;
+            border-radius: 50%;
+            border: 1px solid rgba(0, 153, 255, 0.35);
+            box-shadow: 0 0 30px rgba(0, 153, 255, 0.35), inset 0 0 30px rgba(0, 153, 255, 0.2);
+            transform-style: preserve-3d;
+            animation: loading-orbit-tilt 8s ease-in-out infinite;
+        }
+
+        .loading-overlay .loading-orbit::before,
+        .loading-overlay .loading-orbit::after {
+            content: "";
+            position: absolute;
+            inset: -18px;
+            border-radius: 50%;
+            border: 1px solid rgba(0, 153, 255, 0.12);
+            transform: translateZ(-50px);
+            filter: blur(1px);
+        }
+
+        .loading-overlay .loading-orbit::after {
+            inset: -32px;
+            border-color: rgba(0, 153, 255, 0.08);
+        }
+
+        .loading-overlay .loading-planet {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 52px;
+            height: 52px;
+            border-radius: 50%;
+            background: radial-gradient(circle at 30% 30%, #9cf1ff, #0070ff 55%, #001950);
+            transform: translate(-50%, -50%) translateZ(32px);
+            box-shadow: 0 0 40px rgba(0, 153, 255, 0.6), inset -8px -10px 20px rgba(0, 0, 0, 0.45);
+        }
+
+        .loading-overlay .loading-satellite {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 18px;
+            height: 18px;
+            border-radius: 50%;
+            background: radial-gradient(circle at 30% 30%, #fff, #66d1ff);
+            box-shadow: 0 0 15px rgba(102, 209, 255, 0.9);
+            transform-origin: -70px;
+            animation: loading-satellite 3.2s linear infinite;
+        }
+
+        .loading-overlay .loading-satellite::after {
+            content: "";
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 60px;
+            height: 2px;
+            background: linear-gradient(90deg, rgba(102, 209, 255, 0.8), rgba(102, 209, 255, 0));
+            transform: translate(-100%, -50%) rotateY(50deg);
+            opacity: 0.7;
+            filter: blur(0.5px);
+        }
+
+        .loading-overlay .loading-text {
+            font-size: 0.9rem;
+            letter-spacing: 0.45em;
+            text-shadow: 0 0 12px rgba(0, 153, 255, 0.8);
+            animation: loading-pulse 2.4s ease-in-out infinite;
+        }
+
+        @keyframes loading-float {
+            0%, 100% {
+                transform: translateY(0) translateZ(0);
+            }
+            50% {
+                transform: translateY(-14px) translateZ(30px);
+            }
+        }
+
+        @keyframes loading-orbit-tilt {
+            0% {
+                transform: rotateX(20deg) rotateZ(0deg);
+            }
+            50% {
+                transform: rotateX(34deg) rotateZ(180deg);
+            }
+            100% {
+                transform: rotateX(20deg) rotateZ(360deg);
+            }
+        }
+
+        @keyframes loading-satellite {
+            0% {
+                transform: rotateZ(0deg) rotateX(0deg);
+            }
+            100% {
+                transform: rotateZ(360deg) rotateX(360deg);
+            }
+        }
+
+        @keyframes loading-pulse {
+            0%, 100% {
+                opacity: 0.6;
+            }
+            50% {
+                opacity: 1;
+            }
         }
         
         .terminal {
@@ -870,11 +991,21 @@
             if (iframe) {
                 const loader = document.createElement('div');
                 loader.className = 'loading-overlay';
-                loader.textContent = 'Loading...';
+                loader.innerHTML = `
+                    <div class="loading-scene" role="status" aria-live="polite">
+                        <div class="loading-orbit">
+                            <div class="loading-planet"></div>
+                            <div class="loading-satellite"></div>
+                        </div>
+                        <div class="loading-text">Loading</div>
+                    </div>
+                `;
+                loader.setAttribute('aria-busy', 'true');
                 const contentEl = winEl.querySelector('.window-content');
                 contentEl.appendChild(loader);
+                const removeLoader = () => loader.remove();
                 iframe.addEventListener('load', () => {
-                    loader.remove();
+                    removeLoader();
                     if (type === 'document-editor') {
                         docuBridge.frameWindow = iframe.contentWindow;
                         docuBridge.ready = false;
@@ -882,7 +1013,8 @@
                     if (type === 'scanx') {
                         scanxFrames.add(iframe.contentWindow);
                     }
-                });
+                }, { once: true });
+                iframe.addEventListener('error', removeLoader, { once: true });
                 if (type === 'document-editor') {
                     docuBridge.frameWindow = iframe.contentWindow;
                     docuBridge.ready = false;
@@ -1040,10 +1172,10 @@
             }
         });
         
-       function closeWindow(id) {
-           const window = document.getElementById(id);
-            if (!window) return;
-            const type = window.dataset.windowType;
+        function closeWindow(id) {
+            const win = document.getElementById(id);
+            if (!win) return;
+            const type = win.dataset.windowType;
             if (type === 'document-editor') {
                 docuBridge.ready = false;
                 docuBridge.frameWindow = null;
@@ -1051,22 +1183,70 @@
                 docuBridge.queue.length = 0;
             }
             if (type === 'scanx') {
-                const frame = window.querySelector('iframe');
+                const frame = win.querySelector('iframe');
                 if (frame && frame.contentWindow) {
                     scanxFrames.delete(frame.contentWindow);
                 }
             }
-            // run cleanup for special windows such as console log
-            if (window._restoreConsole) {
-                window._restoreConsole();
+            if (persistWindows && type) {
+                delete windowStates[type];
+                localStorage.setItem('windowStates', JSON.stringify(windowStates));
             }
-            window.classList.add('zoom-out');
-            window.addEventListener('transitionend', () => {
-                window.remove();
+            if (win._restoreConsole) {
+                win._restoreConsole();
+            }
+
+            let cleaned = false;
+            const cleanup = () => {
+                if (cleaned) return;
+                cleaned = true;
+                if (win.isConnected) {
+                    win.remove();
+                }
                 console.log('Window closed:', id);
-                state.windows = state.windows.filter(winId => winId !== id);
-                updateTaskBar();
-            }, { once: true });
+            };
+
+            state.windows = state.windows.filter(winId => winId !== id);
+            updateTaskBar();
+
+            const style = getComputedStyle(win);
+            const parseTimeList = value => value.split(',').map(part => {
+                const trimmed = part.trim();
+                if (!trimmed) return 0;
+                if (trimmed.endsWith('ms')) return parseFloat(trimmed) || 0;
+                if (trimmed.endsWith('s')) return (parseFloat(trimmed) || 0) * 1000;
+                const numeric = parseFloat(trimmed);
+                return Number.isFinite(numeric) ? numeric * 1000 : 0;
+            });
+            const durations = parseTimeList(style.transitionDuration || '0s');
+            const delays = parseTimeList(style.transitionDelay || '0s');
+            const count = Math.max(durations.length, delays.length);
+            let maxDuration = 0;
+            for (let i = 0; i < count; i++) {
+                const duration = durations[i] ?? durations[durations.length - 1] ?? 0;
+                const delay = delays[i] ?? delays[delays.length - 1] ?? 0;
+                maxDuration = Math.max(maxDuration, duration + delay);
+            }
+
+            const finish = () => {
+                cleanup();
+            };
+
+            if (!win.classList.contains('zoom-out')) {
+                win.classList.add('zoom-out');
+            }
+
+            if (maxDuration > 0) {
+                const fallback = setTimeout(finish, maxDuration + 50);
+                win.addEventListener('transitionend', event => {
+                    if (event.target === win) {
+                        clearTimeout(fallback);
+                        finish();
+                    }
+                }, { once: true });
+            } else {
+                finish();
+            }
         }
 
        function minimizeWindow(id) {

--- a/mini_os.html
+++ b/mini_os.html
@@ -272,10 +272,131 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            background: rgba(255, 255, 255, 0.7);
-            color: #000;
-            font-size: 18px;
+            background: radial-gradient(circle at 20% 20%, rgba(10, 25, 60, 0.88), rgba(0, 0, 0, 0.92));
+            color: #fff;
             z-index: 5;
+            perspective: 1000px;
+            backdrop-filter: blur(8px);
+        }
+
+        .loading-overlay .loading-scene {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 24px;
+            transform-style: preserve-3d;
+            animation: loading-float 4.5s ease-in-out infinite;
+        }
+
+        .loading-overlay .loading-orbit {
+            position: relative;
+            width: 140px;
+            height: 140px;
+            border-radius: 50%;
+            border: 1px solid rgba(0, 153, 255, 0.35);
+            box-shadow: 0 0 30px rgba(0, 153, 255, 0.35), inset 0 0 30px rgba(0, 153, 255, 0.2);
+            transform-style: preserve-3d;
+            animation: loading-orbit-tilt 8s ease-in-out infinite;
+        }
+
+        .loading-overlay .loading-orbit::before,
+        .loading-overlay .loading-orbit::after {
+            content: "";
+            position: absolute;
+            inset: -18px;
+            border-radius: 50%;
+            border: 1px solid rgba(0, 153, 255, 0.12);
+            transform: translateZ(-50px);
+            filter: blur(1px);
+        }
+
+        .loading-overlay .loading-orbit::after {
+            inset: -32px;
+            border-color: rgba(0, 153, 255, 0.08);
+        }
+
+        .loading-overlay .loading-planet {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 52px;
+            height: 52px;
+            border-radius: 50%;
+            background: radial-gradient(circle at 30% 30%, #9cf1ff, #0070ff 55%, #001950);
+            transform: translate(-50%, -50%) translateZ(32px);
+            box-shadow: 0 0 40px rgba(0, 153, 255, 0.6), inset -8px -10px 20px rgba(0, 0, 0, 0.45);
+        }
+
+        .loading-overlay .loading-satellite {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 18px;
+            height: 18px;
+            border-radius: 50%;
+            background: radial-gradient(circle at 30% 30%, #fff, #66d1ff);
+            box-shadow: 0 0 15px rgba(102, 209, 255, 0.9);
+            transform-origin: -70px;
+            animation: loading-satellite 3.2s linear infinite;
+        }
+
+        .loading-overlay .loading-satellite::after {
+            content: "";
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 60px;
+            height: 2px;
+            background: linear-gradient(90deg, rgba(102, 209, 255, 0.8), rgba(102, 209, 255, 0));
+            transform: translate(-100%, -50%) rotateY(50deg);
+            opacity: 0.7;
+            filter: blur(0.5px);
+        }
+
+        .loading-overlay .loading-text {
+            font-size: 0.9rem;
+            letter-spacing: 0.45em;
+            text-shadow: 0 0 12px rgba(0, 153, 255, 0.8);
+            animation: loading-pulse 2.4s ease-in-out infinite;
+        }
+
+        @keyframes loading-float {
+            0%, 100% {
+                transform: translateY(0) translateZ(0);
+            }
+            50% {
+                transform: translateY(-14px) translateZ(30px);
+            }
+        }
+
+        @keyframes loading-orbit-tilt {
+            0% {
+                transform: rotateX(20deg) rotateZ(0deg);
+            }
+            50% {
+                transform: rotateX(34deg) rotateZ(180deg);
+            }
+            100% {
+                transform: rotateX(20deg) rotateZ(360deg);
+            }
+        }
+
+        @keyframes loading-satellite {
+            0% {
+                transform: rotateZ(0deg) rotateX(0deg);
+            }
+            100% {
+                transform: rotateZ(360deg) rotateX(360deg);
+            }
+        }
+
+        @keyframes loading-pulse {
+            0%, 100% {
+                opacity: 0.6;
+            }
+            50% {
+                opacity: 1;
+            }
         }
         
         .terminal {
@@ -871,9 +992,20 @@
             if (iframe) {
                 const loader = document.createElement('div');
                 loader.className = 'loading-overlay';
-                loader.textContent = 'Loading...';
+                loader.innerHTML = `
+                    <div class="loading-scene" role="status" aria-live="polite">
+                        <div class="loading-orbit">
+                            <div class="loading-planet"></div>
+                            <div class="loading-satellite"></div>
+                        </div>
+                        <div class="loading-text">Loading</div>
+                    </div>
+                `;
+                loader.setAttribute('aria-busy', 'true');
                 winEl.querySelector('.window-content').appendChild(loader);
-                iframe.addEventListener('load', () => loader.remove());
+                const removeLoader = () => loader.remove();
+                iframe.addEventListener('load', removeLoader, { once: true });
+                iframe.addEventListener('error', removeLoader, { once: true });
             }
             if (type === 'console-log') {
                 // lazily load console log handler and keep restore callback
@@ -912,20 +1044,69 @@
             return { title: cfg.title, content, width: cfg.width, height: cfg.height };
         }
         
-       function closeWindow(id) {
-           const window = document.getElementById(id);
-            if (!window) return;
-            // run cleanup for special windows such as console log
-            if (window._restoreConsole) {
-                window._restoreConsole();
+        function closeWindow(id) {
+            const win = document.getElementById(id);
+            if (!win) return;
+            const type = win.dataset.windowType;
+            if (persistWindows && type) {
+                delete windowStates[type];
+                localStorage.setItem('windowStates', JSON.stringify(windowStates));
             }
-            window.classList.add('zoom-out');
-            window.addEventListener('transitionend', () => {
-                window.remove();
+            if (win._restoreConsole) {
+                win._restoreConsole();
+            }
+
+            let cleaned = false;
+            const cleanup = () => {
+                if (cleaned) return;
+                cleaned = true;
+                if (win.isConnected) {
+                    win.remove();
+                }
                 console.log('Window closed:', id);
-                state.windows = state.windows.filter(winId => winId !== id);
-                updateTaskBar();
-            }, { once: true });
+            };
+
+            state.windows = state.windows.filter(winId => winId !== id);
+            updateTaskBar();
+
+            const style = getComputedStyle(win);
+            const parseTimeList = value => value.split(',').map(part => {
+                const trimmed = part.trim();
+                if (!trimmed) return 0;
+                if (trimmed.endsWith('ms')) return parseFloat(trimmed) || 0;
+                if (trimmed.endsWith('s')) return (parseFloat(trimmed) || 0) * 1000;
+                const numeric = parseFloat(trimmed);
+                return Number.isFinite(numeric) ? numeric * 1000 : 0;
+            });
+            const durations = parseTimeList(style.transitionDuration || '0s');
+            const delays = parseTimeList(style.transitionDelay || '0s');
+            const count = Math.max(durations.length, delays.length);
+            let maxDuration = 0;
+            for (let i = 0; i < count; i++) {
+                const duration = durations[i] ?? durations[durations.length - 1] ?? 0;
+                const delay = delays[i] ?? delays[delays.length - 1] ?? 0;
+                maxDuration = Math.max(maxDuration, duration + delay);
+            }
+
+            const finish = () => {
+                cleanup();
+            };
+
+            if (!win.classList.contains('zoom-out')) {
+                win.classList.add('zoom-out');
+            }
+
+            if (maxDuration > 0) {
+                const fallback = setTimeout(finish, maxDuration + 50);
+                win.addEventListener('transitionend', event => {
+                    if (event.target === win) {
+                        clearTimeout(fallback);
+                        finish();
+                    }
+                }, { once: true });
+            } else {
+                finish();
+            }
         }
 
        function minimizeWindow(id) {


### PR DESCRIPTION
## Summary
- ensure closing a window immediately updates the task bar and cleans up persisted state even if transitions fail
- replace the iframe loading overlay with a cinematic 3D-style animation and accessibility improvements
- add defensive timing logic so close animations always remove their windows after the transition

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d94717726c832a80dfbfb15a0fbb12