### PR TITLE
Gracefully fall back to full PDF.js when browser lacks DecompressionStream

### DIFF
--- a/apps/app1/scanx.html
+++ b/apps/app1/scanx.html
@@ -270,14 +270,22 @@
     }
 
     async function ensurePdfJsLoaded() {
-      if (window.pdfjsLib) {
+      if (window.pdfjsLib && !window.pdfjsLib.__scanxLiteUnsupported) {
         configurePdfJs(PDFJS_SOURCES[0]);
         return window.pdfjsLib;
       }
       for (const source of PDFJS_SOURCES) {
         try {
           await loadScript(source.script);
+          if (window.__scanxPdfjsLiteUnsupported) {
+            delete window.__scanxPdfjsLiteUnsupported;
+            continue;
+          }
           if (window.pdfjsLib) {
+            if (window.pdfjsLib.__scanxLiteUnsupported) {
+              delete window.pdfjsLib;
+              continue;
+            }
             configurePdfJs(source);
             return window.pdfjsLib;
           }

--- a/shared/vendor/scanx/pdfjs-lite.js
+++ b/shared/vendor/scanx/pdfjs-lite.js
@@ -1,4 +1,20 @@
 (function(global) {
+  const hasDecompressionStream = typeof global.DecompressionStream === 'function';
+  if (!hasDecompressionStream) {
+    global.__scanxPdfjsLiteUnsupported = 'missing-decompression-stream';
+    if (!global.pdfjsLib || global.pdfjsLib.__scanxLite) {
+      if (!global.pdfjsLib) {
+        global.pdfjsLib = { __scanxLiteUnsupported: 'missing-decompression-stream' };
+      } else {
+        global.pdfjsLib.__scanxLiteUnsupported = 'missing-decompression-stream';
+      }
+    }
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('ScanX lite PDF parser disabled: DecompressionStream is not available.');
+    }
+    return;
+  }
+
   if (global.pdfjsLib) {
     return;
   }
@@ -530,7 +546,7 @@
     }
   };
 
-  global.pdfjsLib = {
+  const liteApi = {
     getDocument(params) {
       const data = params && params.data ? params.data : null;
       if (!data) {
@@ -542,4 +558,6 @@
     GlobalWorkerOptions: { workerSrc: null },
     Util
   };
+  liteApi.__scanxLite = true;
+  global.pdfjsLib = liteApi;
 })(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
- detect when the lite PDF parser cannot run because DecompressionStream is unavailable
- skip registering the lite parser and let ScanX load a CDN-hosted PDF.js build instead
- make the loader ignore unsupported placeholders so the full library is configured correctly

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d97eba15d4832abf50ae23de55cd34