### PR TITLE
Remove Orbit OS boot theme picker

### DIFF
--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -733,19 +733,6 @@
         <div class="task-bar" id="task-bar"></div>
         <div class="taskbar-menu" id="taskbar-menu" style="display:none;"></div>
         
-        <!-- Theme selection dialog -->
-        <div class="dialog" id="theme-dialog" style="display:none;">
-            <div class="window-header">
-                <div class="window-title">Select Theme</div>
-            </div>
-            <div class="dialog-content">
-                <div class="dialog-buttons">
-                    <div class="dialog-btn" data-theme="retro">Retro</div>
-                    <div class="dialog-btn" data-theme="futuristic">Futuristic</div>
-                </div>
-            </div>
-        </div>
-
         <!-- Welcome dialog -->
         <div class="dialog" id="welcome-dialog" style="display:none;">
             <div class="window-header">
@@ -1505,21 +1492,6 @@
             }
         }
         
-        function selectThemeDialog() {
-            return new Promise(resolve => {
-                const dialog = document.getElementById('theme-dialog');
-                dialog.style.display = 'block';
-                dialog.querySelectorAll('.dialog-btn').forEach(btn => {
-                    btn.onclick = () => {
-                        const theme = btn.dataset.theme;
-                        setTheme(theme);
-                        closeDialog('theme-dialog');
-                        resolve(theme);
-                    };
-                });
-            });
-        }
-
         function closeDialog(id) {
             document.getElementById(id).style.display = 'none';
         }
@@ -1556,7 +1528,6 @@
             await delay(280);
             await hideBootLoader();
 
-            await selectThemeDialog();
             buildWelcome(appData.welcome);
             openWindow('console-log');
             bootLoaderBusy = false;

--- a/mini_os.html
+++ b/mini_os.html
@@ -736,19 +736,6 @@
         <div class="task-bar" id="task-bar"></div>
         <div class="taskbar-menu" id="taskbar-menu" style="display:none;"></div>
         
-        <!-- Theme selection dialog -->
-        <div class="dialog" id="theme-dialog" style="display:none;">
-            <div class="window-header">
-                <div class="window-title">Select Theme</div>
-            </div>
-            <div class="dialog-content">
-                <div class="dialog-buttons">
-                    <div class="dialog-btn" data-theme="retro">Retro</div>
-                    <div class="dialog-btn" data-theme="futuristic">Futuristic</div>
-                </div>
-            </div>
-        </div>
-
         <!-- Welcome dialog -->
         <div class="dialog" id="welcome-dialog" style="display:none;">
             <div class="window-header">
@@ -1316,25 +1303,10 @@
             }
         }
         
-        function selectThemeDialog() {
-            return new Promise(resolve => {
-                const dialog = document.getElementById('theme-dialog');
-                dialog.style.display = 'block';
-                dialog.querySelectorAll('.dialog-btn').forEach(btn => {
-                    btn.onclick = () => {
-                        const theme = btn.dataset.theme;
-                        setTheme(theme);
-                        closeDialog('theme-dialog');
-                        resolve(theme);
-                    };
-                });
-            });
-        }
-
         function closeDialog(id) {
             document.getElementById(id).style.display = 'none';
         }
-        
+
         // Initialize everything
         async function init() {
             showBootLoader('Initializing video BIOS…');
@@ -1367,7 +1339,6 @@
             await delay(280);
             await hideBootLoader();
 
-            await selectThemeDialog();
             buildWelcome(appData.welcome);
             openWindow('console-log');
             bootLoaderBusy = false;


### PR DESCRIPTION
## Summary
- remove the Orbit OS boot theme selection dialog markup
- skip waiting on theme selection so boot continues directly to the welcome experience

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dafc37faf4832a87fef65060b7a12d