### PR TITLE
Use extracted PDF text for ScanX columns

### DIFF
--- a/apps/app1/scanx.html
+++ b/apps/app1/scanx.html
@@ -550,9 +550,15 @@
       });
       if (current.length) paragraphs.push(current);
       const html = paragraphs.map(group => {
-        const original = group.map(item => item.text).join(' ');
-        const words = original.split(/\s+/).filter(Boolean).length;
-        return `<p>${escapeHtml(buildLoremParagraph(Math.max(words, 35)))}</p>`;
+        const original = group
+          .map(item => item.text)
+          .join(' ')
+          .replace(/\s+/g, ' ')
+          .trim();
+        if (!original) {
+          return `<p>${escapeHtml(buildLoremParagraph(35))}</p>`;
+        }
+        return `<p>${escapeHtml(original)}</p>`;
       }).join('') || `<p>${escapeHtml(buildLoremParagraph(40))}</p>`;
       return {
         html,


### PR DESCRIPTION
## Summary
- render extracted PDF text when rebuilding column windows so the generated document reflects the uploaded content
- keep a lorem fallback only when a column provides no usable text to preserve layout previews

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dafeb208ac832abc555ff6edbf9eff