### PR TITLE
Hide Docu Monster rulers on mobile

### DIFF
--- a/apps/app1/documonster.html
+++ b/apps/app1/documonster.html
@@ -1936,6 +1936,7 @@
       mobileAutoZoomed = false;
     }
     syncMobileToggleState();
+    buildRulers();
   }
 
   if(zoomInBtn) zoomInBtn.addEventListener('click', zoomIn);
@@ -2313,6 +2314,11 @@
   selColorPreset.addEventListener('change', applyColorPreset);
 
   function buildRulers(){
+    if(document.body.classList.contains('mobile-layout')){
+      rulerTopEl.style.display = 'none';
+      rulerLeftEl.style.display = 'none';
+      return;
+    }
     if(!pages.length){
       rulerTopEl.style.display = 'none';
       rulerLeftEl.style.display = 'none';


### PR DESCRIPTION
## Summary
- skip ruler rendering while Docu Monster Studio Pro is in the mobile layout to avoid oversized overlays
- rebuild ruler visibility after applying the mobile state so desktop layouts continue to show guides when resizing back

## Testing
- Manual verification in Playwright at 400px width

------
https://chatgpt.com/codex/tasks/task_e_68db05a9be78832ab32b4d2e548e926e