### PR TITLE
Handle missing WebGL2 context without illegal return

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -1326,7 +1326,7 @@
   if (!gl) {
     console.error('WebGL2 is required for the Terrain experience.');
     hideLoader(false);
-    return;
+    throw new Error('WebGL2 is required for the Terrain experience.');
   }
 
   const ZX_PALETTE = retroPalettes.zx.map(hex => [


### PR DESCRIPTION
## Summary
- replace the top-level `return` used when WebGL2 is unavailable with an exception so script evaluation stops without a syntax error
- keep the loader reset and error logging intact while avoiding illegal control flow in module scope

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb0b6920c832ab46f04329349c2e0