### PR TITLE
Fix Terrain camera height calculation

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -1912,7 +1912,12 @@
     const sinPitch = Math.sin(camera.pitch);
     const distance = camera.distance;
     camera.position[0] = camera.target[0] + Math.sin(camera.yaw) * cosPitch * distance;
-    camera.position[1] = camera.target[1] + sinPitch * distance;
+    // When the pitch is negative we want the camera to sit *above* the
+    // terrain and look downward. The previous implementation added the
+    // vertical component directly which placed the camera underneath the
+    // ground, leaving the mesh culled from view. Flip the sign so that the
+    // camera height increases as the pitch drops below zero.
+    camera.position[1] = camera.target[1] - sinPitch * distance;
     camera.position[2] = camera.target[2] + Math.cos(camera.yaw) * cosPitch * distance;
 
     const dx = camera.target[0] - camera.lastTarget[0];


### PR DESCRIPTION
## Summary
- ensure the orbit camera stays above the terrain when using negative pitch angles
- add clarifying comment about why the vertical offset uses an inverted sign

## Testing
- python3 -m http.server 8000 (manual verification of Terrain view)


------
https://chatgpt.com/codex/tasks/task_e_68dbc4f058d0832a82acc5d2d4d460cd