### PR TITLE
Fix Terrain camera navigation regression

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -1880,7 +1880,7 @@
   }
 
   function updateCamera(dt) {
-    const forward = [Math.sin(camera.yaw), 0, Math.cos(camera.yaw)];
+    const forward = [-Math.sin(camera.yaw), 0, -Math.cos(camera.yaw)];
     const right = [Math.cos(camera.yaw), 0, -Math.sin(camera.yaw)];
     let moveX = 0;
     let moveZ = 0;
@@ -1912,12 +1912,7 @@
     const sinPitch = Math.sin(camera.pitch);
     const distance = camera.distance;
     camera.position[0] = camera.target[0] + Math.sin(camera.yaw) * cosPitch * distance;
-    // When the pitch is negative we want the camera to sit *above* the
-    // terrain and look downward. The previous implementation added the
-    // vertical component directly which placed the camera underneath the
-    // ground, leaving the mesh culled from view. Flip the sign so that the
-    // camera height increases as the pitch drops below zero.
-    camera.position[1] = camera.target[1] - sinPitch * distance;
+    camera.position[1] = camera.target[1] + sinPitch * distance;
     camera.position[2] = camera.target[2] + Math.cos(camera.yaw) * cosPitch * distance;
 
     const dx = camera.target[0] - camera.lastTarget[0];


### PR DESCRIPTION
## Summary
- restore the Terrain camera height calculation to match the previous behavior
- align keyboard navigation with the camera heading so forward/backward keys move in the expected directions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbdfed44d4832a8783c1c1b88744ce