### PR TITLE
Improve terrain shaping and align orbit controls

### DIFF
--- a/js/scene.js
+++ b/js/scene.js
@@ -53,9 +53,15 @@ export function initScene(container, fpsCounter) {
   const groundSize = 32;
   const groundGeo = new THREE.PlaneGeometry(groundSize, groundSize, groundSize, groundSize);
   const pos = groundGeo.attributes.position;
+  const amplitude = 1.6;
+  const frequency = 0.45;
   for (let i = 0; i < pos.count; i++) {
-    const height = i % 2 === 0 ? 0 : -1;
-    pos.setZ(i, height);
+    const x = pos.getX(i);
+    const y = pos.getY(i);
+    const ridge = Math.sin(x * frequency) * Math.cos(y * frequency);
+    const falloff = Math.exp(-(x * x + y * y) / (groundSize * 3));
+    const height = ridge * amplitude * falloff;
+    pos.setZ(i, Math.max(height, -0.6));
   }
   groundGeo.computeVertexNormals();
 

--- a/js/script.js
+++ b/js/script.js
@@ -277,8 +277,8 @@ function setupTouchControls() {
 
   bindPress(forwardBtn, () => setForwardTarget(1), () => setForwardTarget(0));
   bindPress(backBtn, () => setForwardTarget(-1), () => setForwardTarget(0));
-  bindPress(leftBtn, () => setOrbitTarget(1), () => setOrbitTarget(0));
-  bindPress(rightBtn, () => setOrbitTarget(-1), () => setOrbitTarget(0));
+  bindPress(leftBtn, () => setOrbitTarget(-1), () => setOrbitTarget(0));
+  bindPress(rightBtn, () => setOrbitTarget(1), () => setOrbitTarget(0));
   bindPress(zoomInBtn, () => setZoomDirection(-1), () => setZoomDirection(0));
   bindPress(zoomOutBtn, () => setZoomDirection(1), () => setZoomDirection(0));
 }


### PR DESCRIPTION
## Summary
- generate a smoother height field for the ground mesh so it reads as terrain under the camera
- limit the valley depth to keep the surface above the camera origin and maintain proper lighting
- align the touch orbit buttons with their intended rotation directions

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68dbf57c65cc832a833a9b20f4c7887e