### PR TITLE
Revamp Orbit OS utilities for 0.1.2

### DIFF
--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -16,7 +16,7 @@
           "type": "file-manager"
         },
         {
-          "label": "Exit Orbit OS v 0.1.1"
+          "label": "Exit Orbit OS v 0.1.2"
         }
       ]
     },
@@ -50,10 +50,6 @@
         {
           "label": "Calendar",
           "type": "calendar"
-        },
-        {
-          "label": "Puzzle Game",
-          "type": "puzzle-game"
         },
         {
           "label": "Console Log",
@@ -98,17 +94,16 @@
       ]
     }
   ],
-  "status": "Ready.",
+  "status": "Orbit OS v 0.1.2 ready.",
   "welcome": {
-    "title": "Orbit OS v 0.1.1",
+    "title": "Orbit OS v 0.1.2",
     "lines": [
-      "Welcome to Orbit OS v 0.1.1.",
+      "Welcome to Orbit OS v 0.1.2.",
       "Built in-house for independent creators.",
       "(c) 2025 CyborgsDream"
     ],
     "button": "OK"
   },
-  "puzzleSolved": "Congratulations! Puzzle solved!",
   "icons": [
     {
       "type": "terminal",
@@ -141,11 +136,6 @@
       "label": "Calendar"
     },
     {
-      "type": "puzzle-game",
-      "emoji": "🧩",
-      "label": "Puzzle"
-    },
-    {
       "type": "clock",
       "emoji": "⏰",
       "label": "Clock"
@@ -164,21 +154,21 @@
   "windows": {
     "system-info": {
       "title": "System Information",
-      "content": "<h2>Orbit OS v 0.1.1 Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>Orbit OS v 0.1.1</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Creative Control</div></div>",
+      "content": "<h2>Orbit OS v 0.1.2 Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>Orbit OS v 0.1.2</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Creative Control</div></div>",
       "width": 320,
       "height": 300
     },
     "terminal": {
       "title": "CLI",
-      "content": "<div class=\"terminal\"><div class=\"terminal-line\">Orbit OS v 0.1.1 CLI</div><div class=\"terminal-line\">(c) 2025 CyborgsDream</div><div class=\"terminal-line\">Orbit OS v 0.1.1 started.</div><div class=\"terminal-line\">System date: {DATE}</div><div class=\"terminal-line\">System time: {TIME}</div><div class=\"terminal-line\"><br></div><div class=\"terminal-line\"><span class=\"prompt\">1&gt;</span> <span class=\"cursor\">█</span></div></div>",
-      "width": 450,
-      "height": 250
+      "content": "<div class=\"terminal\" role=\"application\"><div class=\"terminal-screen\" tabindex=\"0\" aria-label=\"Orbit OS command line\"><div class=\"terminal-output\"></div><div class=\"terminal-input-line\"><span class=\"terminal-prompt\">orbit&gt;</span><span class=\"terminal-input\" aria-live=\"polite\"></span><span class=\"terminal-cursor\">█</span></div></div><div class=\"terminal-hints\">Type <strong>help</strong> to list available commands.</div></div>",
+      "width": 520,
+      "height": 320
     },
     "text-editor": {
       "title": "Text Editor",
-      "content": "<div class=\"text-editor\" style=\"display:flex;flex-direction:column;height:100%\"><div style=\"text-align:right;margin-bottom:5px;\"><button id=\"text-editor-export\" style=\"font-size:16px;\">Export PDF</button></div><textarea id=\"text-editor-area\" style=\"flex:1;background:#fff;border:1px solid #aaa;padding:5px;font-family:monospace;font-size:18px;\">Welcome to Orbit OS v 0.1.1!\n\n• Crafted for focused creative work.\n• Windows snap, remember their state, and respect your layout.\n• Use the status bar for live service feedback.\n\nStay tuned for additional native tools in upcoming builds.</textarea></div>",
-      "width": 500,
-      "height": 350
+      "content": "<div class=\"text-editor\"><div class=\"text-editor-toolbar\"><div class=\"text-editor-menu\"><button data-action=\"new\" class=\"text-editor-btn\">New</button><button data-action=\"save\" class=\"text-editor-btn\">Save</button><button data-action=\"load\" class=\"text-editor-btn\">Load</button><button data-action=\"word-count\" class=\"text-editor-btn\">Word Count</button></div><div class=\"text-editor-spacer\"></div><button id=\"text-editor-export\" class=\"text-editor-btn primary\">Export PDF</button></div><div class=\"text-editor-status-row\"><div id=\"text-editor-status\">Ready.</div><div id=\"text-editor-stats\"></div></div><textarea id=\"text-editor-area\" class=\"text-editor-area\">Welcome to Orbit OS v 0.1.2!\n\n• Crafted for focused creative work.\n• Windows snap, remember their state, and respect your layout.\n• Use the menu above to manage drafts.\n\nStay tuned for additional native tools in upcoming builds.</textarea></div>",
+      "width": 560,
+      "height": 420
     },
     "calculator": {
         "title": "Calculator",
@@ -192,17 +182,11 @@
       "width": 350,
       "height": 300
     },
-    "puzzle-game": {
-      "title": "15 Puzzle",
-      "content": "<div class=\"game-container\"><h3>15 Puzzle</h3><p>Slide the tiles to arrange them in order</p><div class=\"game-board\" id=\"puzzle-board\"></div><button onclick=\"initPuzzleGame()\" style=\"margin-top: 10px; padding: 5px 15px; font-size: 18px;\">New Game</button></div>",
-      "width": 300,
-      "height": 400
-    },
     "clock": {
       "title": "Clock",
-      "content": "<div style=\"text-align:center\"><div id=\"live-clock\" style=\"font-size:32px;margin-bottom:10px\">{TIME}</div><button id=\"toggle-clock-format\">24h</button></div>",
-      "width": 200,
-      "height": 170
+      "content": "<div class=\"gshock-clock\" role=\"img\" aria-label=\"CASHIO G-Shock inspired digital clock\"><div class=\"gshock-bezel\">CASHIO<br><span>G-SHOCK</span></div><div class=\"gshock-inner\"><div class=\"gshock-header\"><span id=\"gshock-day\">SUN</span><span class=\"gshock-signal\">SIG</span><span id=\"gshock-mode\">24H</span></div><div class=\"gshock-time\" id=\"gshock-time\">{TIME}</div><div class=\"gshock-footer\"><span id=\"gshock-date\">JAN 01</span><span id=\"gshock-ampm\">AM</span></div></div><div class=\"gshock-buttons\"><button id=\"gshock-toggle\" class=\"gshock-btn\" aria-label=\"Toggle 12 and 24 hour time\">MODE</button></div></div>",
+      "width": 260,
+      "height": 260
     },
     "console-log": {
       "title": "Console Logs",

--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -12,7 +12,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Orbit OS v 0.1.1</title>
+    <title>Orbit OS v 0.1.2</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=VT323&display=swap">
     <style>
         * {
@@ -403,21 +403,72 @@
         }
         
         .terminal {
-            background: #000;
-            color: #0f0;
-            font-family: 'VT323', monospace;
-            padding: 10px;
+            display: flex;
+            flex-direction: column;
             height: 100%;
-            overflow: auto;
-            font-size: 18px;
-        }
-        
-        .terminal-line {
-            margin-bottom: 5px;
-        }
-        
-        .prompt {
+            background: radial-gradient(circle at top, #0a0a0a, #020202 70%);
+            border: 2px solid #0f0;
+            border-radius: 6px;
+            box-shadow: inset 0 0 12px rgba(0, 255, 170, 0.25);
+            font-family: 'VT323', monospace;
             color: #0f0;
+        }
+
+        .terminal-screen {
+            flex: 1;
+            overflow: auto;
+            padding: 12px;
+            outline: none;
+        }
+
+        .terminal-screen:focus {
+            box-shadow: inset 0 0 0 2px rgba(0, 255, 170, 0.4);
+        }
+
+        .terminal-output {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .terminal-row {
+            white-space: pre-wrap;
+            letter-spacing: 1px;
+        }
+
+        .terminal-input-line {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding-top: 6px;
+        }
+
+        .terminal-prompt {
+            color: #5dff89;
+        }
+
+        .terminal-input {
+            min-width: 2px;
+        }
+
+        .terminal-cursor {
+            animation: terminal-blink 1s step-end infinite;
+        }
+
+        @keyframes terminal-blink {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0; }
+        }
+
+        .terminal-hints {
+            padding: 6px 12px;
+            font-size: 14px;
+            background: linear-gradient(90deg, rgba(0, 255, 170, 0.15), transparent);
+            border-top: 1px solid rgba(0, 255, 170, 0.3);
+        }
+
+        .terminal-hints strong {
+            color: #9bffba;
         }
         
         .disk-drive {
@@ -438,6 +489,89 @@
             align-items: center;
             box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.5);
             z-index: 4;
+        }
+
+        .text-editor {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+            background: #fdfdfd;
+            border: 1px solid #bbb;
+            border-radius: 4px;
+            overflow: hidden;
+            font-family: 'VT323', monospace;
+        }
+
+        .text-editor-toolbar {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 8px 10px;
+            background: linear-gradient(to bottom, #ececec, #d8d8d8);
+            border-bottom: 1px solid #b3b3b3;
+        }
+
+        .text-editor-menu {
+            display: flex;
+            gap: 6px;
+        }
+
+        .text-editor-btn {
+            border: 1px solid #888;
+            background: linear-gradient(to bottom, #ffffff, #d9d9d9);
+            padding: 4px 10px;
+            font-size: 16px;
+            cursor: pointer;
+            border-radius: 3px;
+            transition: transform 0.1s ease, box-shadow 0.1s ease;
+        }
+
+        .text-editor-btn:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+        }
+
+        .text-editor-btn.primary {
+            border-color: #0056b3;
+            background: linear-gradient(to bottom, #4aa3ff, #1c6ad6);
+            color: #fff;
+        }
+
+        .text-editor-spacer {
+            flex: 1;
+        }
+
+        .text-editor-status-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 6px 10px;
+            background: #f0f0f0;
+            font-size: 14px;
+            border-bottom: 1px solid #c9c9c9;
+        }
+
+        #text-editor-status[data-state="warning"] {
+            color: #c67d00;
+        }
+
+        #text-editor-status[data-state="success"] {
+            color: #0a8a37;
+        }
+
+        .text-editor-area {
+            flex: 1;
+            border: none;
+            padding: 12px;
+            font-size: 18px;
+            font-family: 'VT323', monospace;
+            outline: none;
+            resize: none;
+            background: #ffffff;
+        }
+
+        .text-editor-area:focus {
+            box-shadow: inset 0 0 0 2px rgba(0, 123, 255, 0.2);
         }
         
         .drive-slot {
@@ -463,6 +597,94 @@
             0% { opacity: 0.3; }
             50% { opacity: 1; }
             100% { opacity: 0.3; }
+        }
+
+        .gshock-clock {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: space-between;
+            height: 100%;
+            padding: 12px;
+            background: radial-gradient(circle at 20% 20%, #30343b, #0c0e12 70%);
+            border: 4px solid #050607;
+            border-radius: 16px;
+            color: #d8f9ff;
+            font-family: 'VT323', monospace;
+        }
+
+        .gshock-bezel {
+            text-align: center;
+            font-size: 18px;
+            letter-spacing: 2px;
+            color: #ffdf3f;
+        }
+
+        .gshock-bezel span {
+            display: block;
+            font-size: 12px;
+            color: #f33535;
+            letter-spacing: 4px;
+        }
+
+        .gshock-inner {
+            width: 100%;
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            background: #101820;
+            border: 2px solid #2f3b44;
+            border-radius: 10px;
+            padding: 12px;
+            box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.6);
+        }
+
+        .gshock-header,
+        .gshock-footer {
+            display: flex;
+            justify-content: space-between;
+            font-size: 14px;
+            color: #8cd9ff;
+        }
+
+        .gshock-time {
+            font-size: 36px;
+            text-align: center;
+            color: #9bf7ff;
+            text-shadow: 0 0 10px rgba(155, 247, 255, 0.6);
+        }
+
+        .gshock-signal {
+            color: #ffdf3f;
+        }
+
+        .gshock-buttons {
+            display: flex;
+            justify-content: center;
+            margin-top: 10px;
+        }
+
+        .gshock-btn {
+            background: linear-gradient(to bottom, #20242b, #13161c);
+            border: 1px solid #515862;
+            color: #d8f9ff;
+            padding: 4px 12px;
+            font-size: 14px;
+            border-radius: 6px;
+            cursor: pointer;
+            letter-spacing: 2px;
+            transition: transform 0.1s ease, box-shadow 0.1s ease;
+        }
+
+        .gshock-btn:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 3px 6px rgba(0, 0, 0, 0.4);
+        }
+
+        .gshock-btn.active {
+            background: linear-gradient(to bottom, #ffdf3f, #f2b705);
+            color: #101820;
         }
         
         .task-bar {

--- a/apps/app1/app-js/calendar.js
+++ b/apps/app1/app-js/calendar.js
@@ -1,4 +1,8 @@
-WinAPI.createWindow('calendar');
+const id = WinAPI.createWindow('calendar');
+
+const calendarWindow = document.getElementById(id);
+const headerEl = calendarWindow?.querySelector('#calendar-month-year');
+const gridEl = calendarWindow?.querySelector('.calendar-grid');
 
 window.currentDate = new Date();
 
@@ -15,7 +19,7 @@ window.generateCalendarDays = function(date) {
     const today = new Date();
 
     for (let i = 0; i < startDay; i++) {
-        daysHtml += `<div class="calendar-day"></div>`;
+        daysHtml += '<div class="calendar-day"></div>';
     }
 
     for (let day = 1; day <= daysInMonth; day++) {
@@ -28,17 +32,21 @@ window.generateCalendarDays = function(date) {
     return daysHtml;
 };
 
+function renderCalendar(date) {
+    if (headerEl) {
+        headerEl.textContent = date.toLocaleString('default', { month: 'long', year: 'numeric' });
+    }
+    if (gridEl) {
+        while (gridEl.children.length > 7) {
+            gridEl.removeChild(gridEl.lastElementChild);
+        }
+        gridEl.insertAdjacentHTML('beforeend', window.generateCalendarDays(date));
+    }
+}
+
 window.changeMonth = function(direction) {
     window.currentDate.setMonth(window.currentDate.getMonth() + direction);
-    const header = document.getElementById('calendar-month-year');
-    if (header)
-        header.textContent = window.currentDate.toLocaleString('default', { month: 'long', year: 'numeric' });
-
-    const calendarGrid = document.querySelector('.calendar-grid');
-    if (calendarGrid) {
-        for (let i = 7; i < calendarGrid.children.length; i++) {
-            calendarGrid.children[i].remove();
-        }
-        calendarGrid.insertAdjacentHTML('beforeend', window.generateCalendarDays(window.currentDate));
-    }
+    renderCalendar(window.currentDate);
 };
+
+renderCalendar(window.currentDate);

--- a/apps/app1/app-js/clock.js
+++ b/apps/app1/app-js/clock.js
@@ -6,22 +6,39 @@ function getClockLocale() {
 }
 
 const container = document.getElementById(id);
-const el = container?.querySelector('#live-clock');
-const btn = container?.querySelector('#toggle-clock-format');
-let use24 = false;
+const timeEl = container?.querySelector('#gshock-time');
+const dayEl = container?.querySelector('#gshock-day');
+const dateEl = container?.querySelector('#gshock-date');
+const modeEl = container?.querySelector('#gshock-mode');
+const ampmEl = container?.querySelector('#gshock-ampm');
+const toggleBtn = container?.querySelector('#gshock-toggle');
 const locale = getClockLocale();
+let use24 = false;
 
-function update() {
-    if (el) el.textContent = new Date().toLocaleTimeString(locale, { hour12: !use24 });
+function formatTime(date) {
+    if (use24) {
+        return date.toLocaleTimeString('en-GB', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    }
+    const time = date.toLocaleTimeString(locale, { hour12: true, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    return time.replace(/ /g, '');
 }
 
-setInterval(update, 1000);
-update();
-if (btn) {
-    btn.onclick = () => {
+function updateClock() {
+    const now = new Date();
+    if (timeEl) timeEl.textContent = formatTime(now);
+    if (dayEl) dayEl.textContent = now.toLocaleDateString(locale, { weekday: 'short' }).toUpperCase();
+    if (dateEl) dateEl.textContent = now.toLocaleDateString(locale, { month: 'short', day: '2-digit' }).toUpperCase();
+    if (modeEl) modeEl.textContent = use24 ? '24H' : '12H';
+    if (ampmEl) ampmEl.textContent = use24 ? ' ' : now.toLocaleTimeString(locale, { hour12: true }).slice(-2).toUpperCase();
+}
+
+if (toggleBtn) {
+    toggleBtn.addEventListener('click', () => {
         use24 = !use24;
-        btn.textContent = use24 ? '12h' : '24h';
-        console.log('Clock format toggled:', use24 ? '24h' : '12h');
-        update();
-    };
+        toggleBtn.classList.toggle('active');
+        updateClock();
+    });
 }
+
+updateClock();
+setInterval(updateClock, 1000);

--- a/apps/app1/app-js/terminal.js
+++ b/apps/app1/app-js/terminal.js
@@ -1,1 +1,146 @@
-WinAPI.createWindow('terminal');
+const id = WinAPI.createWindow('terminal');
+
+const win = document.getElementById(id);
+const screen = win?.querySelector('.terminal-screen');
+const outputEl = win?.querySelector('.terminal-output');
+const inputEl = win?.querySelector('.terminal-input');
+const hintsEl = win?.querySelector('.terminal-hints');
+
+if (screen) {
+    screen.focus();
+    screen.addEventListener('click', () => screen.focus());
+}
+
+let buffer = '';
+const history = [];
+let historyIndex = -1;
+
+function appendOutput(text = '') {
+    if (!outputEl) return;
+    const lines = Array.isArray(text) ? text : String(text).split('\n');
+    lines.forEach(line => {
+        const div = document.createElement('div');
+        div.className = 'terminal-row';
+        div.textContent = line;
+        outputEl.appendChild(div);
+    });
+    outputEl.parentElement?.scrollTo({ top: outputEl.parentElement.scrollHeight });
+}
+
+function updateInput() {
+    if (!inputEl) return;
+    inputEl.textContent = buffer;
+    outputEl?.parentElement?.scrollTo({ top: outputEl.parentElement.scrollHeight });
+}
+
+function showHints(message) {
+    if (!hintsEl) return;
+    hintsEl.innerHTML = message;
+}
+
+const commands = {
+    help() {
+        appendOutput([
+            'Available commands:',
+            '  help       Show this help message',
+            '  clear      Clear the screen',
+            '  date       Show the current date',
+            '  time       Show the current time',
+            '  version    Display Orbit OS version',
+            '  echo TEXT  Repeat the provided text'
+        ]);
+    },
+    clear() {
+        if (outputEl) outputEl.innerHTML = '';
+    },
+    cls() {
+        commands.clear();
+    },
+    date() {
+        appendOutput(new Date().toLocaleDateString());
+    },
+    time() {
+        appendOutput(new Date().toLocaleTimeString());
+    },
+    version() {
+        appendOutput('Orbit OS v0.1.2');
+    },
+    echo(...args) {
+        appendOutput(args.join(' '));
+    }
+};
+
+function executeCommand(raw) {
+    const input = raw.trim();
+    appendOutput(`orbit> ${input}`);
+    if (!input) return;
+
+    const [cmd, ...args] = input.split(/\s+/);
+    const fn = commands[cmd.toLowerCase()];
+    if (fn) {
+        fn(...args);
+    } else {
+        appendOutput(`Unknown command: ${cmd}. Type "help".`);
+    }
+}
+
+if (screen) {
+    screen.addEventListener('keydown', event => {
+        if (event.key === 'Backspace') {
+            event.preventDefault();
+            buffer = buffer.slice(0, -1);
+            updateInput();
+            return;
+        }
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            const current = buffer;
+            history.push(current);
+            historyIndex = history.length;
+            executeCommand(current);
+            buffer = '';
+            updateInput();
+            return;
+        }
+        if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            if (historyIndex > 0) {
+                historyIndex -= 1;
+                buffer = history[historyIndex] ?? '';
+                updateInput();
+            }
+            return;
+        }
+        if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            if (historyIndex < history.length - 1) {
+                historyIndex += 1;
+                buffer = history[historyIndex] ?? '';
+            } else {
+                historyIndex = history.length;
+                buffer = '';
+            }
+            updateInput();
+            return;
+        }
+        if (event.key === 'Tab') {
+            event.preventDefault();
+            return;
+        }
+        if (event.key.length === 1 && !event.ctrlKey && !event.metaKey) {
+            buffer += event.key;
+            updateInput();
+            return;
+        }
+    });
+}
+
+appendOutput([
+    'Orbit OS v0.1.2 CLI',
+    '(c) 2025 CyborgsDream',
+    `System date: ${new Date().toLocaleDateString()}`,
+    `System time: ${new Date().toLocaleTimeString()}`,
+    ''
+]);
+showHints('Type <strong>help</strong> to list available commands.');
+updateInput();

--- a/apps/app1/app-js/textedit.js
+++ b/apps/app1/app-js/textedit.js
@@ -3,23 +3,114 @@ const id = WinAPI.createWindow('text-editor');
 const win = document.getElementById(id);
 const textarea = win?.querySelector('#text-editor-area');
 const exportBtn = win?.querySelector('#text-editor-export');
+const statusEl = win?.querySelector('#text-editor-status');
+const statsEl = win?.querySelector('#text-editor-stats');
+const menu = win?.querySelector('.text-editor-menu');
 
-function loadJsPDF(callback){
-    if(window.jspdf){ callback(); return; }
-    const script=document.createElement('script');
-    script.src='https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js';
-    script.onload=callback;
+const STORAGE_KEY = 'orbit-textedit-draft';
+let statusTimeout = null;
+
+function loadJsPDF(callback) {
+    if (window.jspdf) {
+        callback();
+        return;
+    }
+    const script = document.createElement('script');
+    script.src = 'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js';
+    script.onload = callback;
     document.head.appendChild(script);
 }
 
-if(exportBtn && textarea){
-    exportBtn.addEventListener('click',()=>{
-        loadJsPDF(()=>{
+function setStatus(message, type = 'info', persist = false) {
+    if (!statusEl) return;
+    statusEl.textContent = message;
+    statusEl.dataset.state = type;
+    if (statusTimeout) {
+        clearTimeout(statusTimeout);
+        statusTimeout = null;
+    }
+    if (!persist) {
+        statusTimeout = setTimeout(() => {
+            if (statusEl.dataset.state === type) {
+                statusEl.textContent = 'Ready.';
+                statusEl.dataset.state = 'info';
+            }
+        }, 4000);
+    }
+}
+
+function updateStats() {
+    if (!textarea || !statsEl) return;
+    const text = textarea.value.trim();
+    const wordCount = text ? text.split(/\s+/).length : 0;
+    const charCount = textarea.value.length;
+    statsEl.textContent = `Words: ${wordCount} | Characters: ${charCount}`;
+}
+
+function handleAction(action) {
+    if (!textarea) return;
+    switch (action) {
+        case 'new':
+            if (textarea.value.trim() && !confirm('Clear the current document?')) {
+                return;
+            }
+            textarea.value = '';
+            updateStats();
+            setStatus('New document created.');
+            break;
+        case 'save':
+            localStorage.setItem(STORAGE_KEY, textarea.value);
+            setStatus('Draft saved to local storage.', 'success');
+            break;
+        case 'load': {
+            const saved = localStorage.getItem(STORAGE_KEY);
+            if (saved == null) {
+                setStatus('No saved draft found.', 'warning');
+            } else {
+                textarea.value = saved;
+                updateStats();
+                setStatus('Draft loaded from local storage.', 'success');
+            }
+            break;
+        }
+        case 'word-count':
+            updateStats();
+            setStatus('Word count updated.', 'info');
+            break;
+    }
+}
+
+if (menu) {
+    menu.addEventListener('click', event => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) return;
+        const action = target.dataset.action;
+        if (action) {
+            event.preventDefault();
+            handleAction(action);
+        }
+    });
+}
+
+if (textarea) {
+    textarea.addEventListener('input', () => {
+        updateStats();
+        setStatus('Editing…');
+    });
+    updateStats();
+}
+
+if (exportBtn && textarea) {
+    exportBtn.addEventListener('click', () => {
+        loadJsPDF(() => {
             const { jsPDF } = window.jspdf;
             const doc = new jsPDF();
-            const lines = doc.splitTextToSize(textarea.value,180);
-            doc.text(lines,10,10);
+            const lines = doc.splitTextToSize(textarea.value || '', 180);
+            doc.text(lines, 10, 10);
             doc.save('document.pdf');
+            setStatus('PDF exported successfully.', 'success');
         });
     });
 }
+
+setStatus('Ready.', 'info', true);

--- a/mini_os.html
+++ b/mini_os.html
@@ -12,7 +12,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Orbit OS v 0.1.1</title>
+    <title>Orbit OS v 0.1.2</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=VT323&display=swap">
     <script>
         window.ORBIT_BASE_PATH = 'apps/app1/';
@@ -392,21 +392,72 @@
         }
         
         .terminal {
-            background: #000;
-            color: #0f0;
-            font-family: 'VT323', monospace;
-            padding: 10px;
+            display: flex;
+            flex-direction: column;
             height: 100%;
-            overflow: auto;
-            font-size: 18px;
-        }
-        
-        .terminal-line {
-            margin-bottom: 5px;
-        }
-        
-        .prompt {
+            background: radial-gradient(circle at top, #0a0a0a, #020202 70%);
+            border: 2px solid #0f0;
+            border-radius: 6px;
+            box-shadow: inset 0 0 12px rgba(0, 255, 170, 0.25);
+            font-family: 'VT323', monospace;
             color: #0f0;
+        }
+
+        .terminal-screen {
+            flex: 1;
+            overflow: auto;
+            padding: 12px;
+            outline: none;
+        }
+
+        .terminal-screen:focus {
+            box-shadow: inset 0 0 0 2px rgba(0, 255, 170, 0.4);
+        }
+
+        .terminal-output {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .terminal-row {
+            white-space: pre-wrap;
+            letter-spacing: 1px;
+        }
+
+        .terminal-input-line {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding-top: 6px;
+        }
+
+        .terminal-prompt {
+            color: #5dff89;
+        }
+
+        .terminal-input {
+            min-width: 2px;
+        }
+
+        .terminal-cursor {
+            animation: terminal-blink 1s step-end infinite;
+        }
+
+        @keyframes terminal-blink {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0; }
+        }
+
+        .terminal-hints {
+            padding: 6px 12px;
+            font-size: 14px;
+            background: linear-gradient(90deg, rgba(0, 255, 170, 0.15), transparent);
+            border-top: 1px solid rgba(0, 255, 170, 0.3);
+        }
+
+        .terminal-hints strong {
+            color: #9bffba;
         }
         
         .disk-drive {
@@ -427,6 +478,89 @@
             align-items: center;
             box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.5);
             z-index: 4;
+        }
+
+        .text-editor {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+            background: #fdfdfd;
+            border: 1px solid #bbb;
+            border-radius: 4px;
+            overflow: hidden;
+            font-family: 'VT323', monospace;
+        }
+
+        .text-editor-toolbar {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 8px 10px;
+            background: linear-gradient(to bottom, #ececec, #d8d8d8);
+            border-bottom: 1px solid #b3b3b3;
+        }
+
+        .text-editor-menu {
+            display: flex;
+            gap: 6px;
+        }
+
+        .text-editor-btn {
+            border: 1px solid #888;
+            background: linear-gradient(to bottom, #ffffff, #d9d9d9);
+            padding: 4px 10px;
+            font-size: 16px;
+            cursor: pointer;
+            border-radius: 3px;
+            transition: transform 0.1s ease, box-shadow 0.1s ease;
+        }
+
+        .text-editor-btn:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+        }
+
+        .text-editor-btn.primary {
+            border-color: #0056b3;
+            background: linear-gradient(to bottom, #4aa3ff, #1c6ad6);
+            color: #fff;
+        }
+
+        .text-editor-spacer {
+            flex: 1;
+        }
+
+        .text-editor-status-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 6px 10px;
+            background: #f0f0f0;
+            font-size: 14px;
+            border-bottom: 1px solid #c9c9c9;
+        }
+
+        #text-editor-status[data-state="warning"] {
+            color: #c67d00;
+        }
+
+        #text-editor-status[data-state="success"] {
+            color: #0a8a37;
+        }
+
+        .text-editor-area {
+            flex: 1;
+            border: none;
+            padding: 12px;
+            font-size: 18px;
+            font-family: 'VT323', monospace;
+            outline: none;
+            resize: none;
+            background: #ffffff;
+        }
+
+        .text-editor-area:focus {
+            box-shadow: inset 0 0 0 2px rgba(0, 123, 255, 0.2);
         }
         
         .drive-slot {
@@ -452,6 +586,94 @@
             0% { opacity: 0.3; }
             50% { opacity: 1; }
             100% { opacity: 0.3; }
+        }
+
+        .gshock-clock {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: space-between;
+            height: 100%;
+            padding: 12px;
+            background: radial-gradient(circle at 20% 20%, #30343b, #0c0e12 70%);
+            border: 4px solid #050607;
+            border-radius: 16px;
+            color: #d8f9ff;
+            font-family: 'VT323', monospace;
+        }
+
+        .gshock-bezel {
+            text-align: center;
+            font-size: 18px;
+            letter-spacing: 2px;
+            color: #ffdf3f;
+        }
+
+        .gshock-bezel span {
+            display: block;
+            font-size: 12px;
+            color: #f33535;
+            letter-spacing: 4px;
+        }
+
+        .gshock-inner {
+            width: 100%;
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            background: #101820;
+            border: 2px solid #2f3b44;
+            border-radius: 10px;
+            padding: 12px;
+            box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.6);
+        }
+
+        .gshock-header,
+        .gshock-footer {
+            display: flex;
+            justify-content: space-between;
+            font-size: 14px;
+            color: #8cd9ff;
+        }
+
+        .gshock-time {
+            font-size: 36px;
+            text-align: center;
+            color: #9bf7ff;
+            text-shadow: 0 0 10px rgba(155, 247, 255, 0.6);
+        }
+
+        .gshock-signal {
+            color: #ffdf3f;
+        }
+
+        .gshock-buttons {
+            display: flex;
+            justify-content: center;
+            margin-top: 10px;
+        }
+
+        .gshock-btn {
+            background: linear-gradient(to bottom, #20242b, #13161c);
+            border: 1px solid #515862;
+            color: #d8f9ff;
+            padding: 4px 12px;
+            font-size: 14px;
+            border-radius: 6px;
+            cursor: pointer;
+            letter-spacing: 2px;
+            transition: transform 0.1s ease, box-shadow 0.1s ease;
+        }
+
+        .gshock-btn:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 3px 6px rgba(0, 0, 0, 0.4);
+        }
+
+        .gshock-btn.active {
+            background: linear-gradient(to bottom, #ffdf3f, #f2b705);
+            color: #101820;
         }
         
         .task-bar {


### PR DESCRIPTION
## Summary
- update Orbit OS assets to version 0.1.2 and remove the unused puzzle application
- rebuild the CLI terminal experience with typed input, history, and helper commands
- expand the text editor toolbar, fix calendar rendering, and redesign the clock with a G-Shock inspired face

## Testing
- no automated tests were run (UI-focused changes)


------
https://chatgpt.com/codex/tasks/task_e_68dd30cc2a9c832aa55e6e157e7cc8a0