### PR TITLE
Fix uniform array locations in terrain shader

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -1680,8 +1680,8 @@
     cameraPos: gl.getUniformLocation(program, 'uCameraPos'),
     renderMode: gl.getUniformLocation(program, 'uRenderMode'),
     gridSize: gl.getUniformLocation(program, 'uGridSize'),
-    zxPalette: gl.getUniformLocation(program, 'uZXPalette'),
-    petsciiPalette: gl.getUniformLocation(program, 'uPetsciiPalette')
+    zxPalette: gl.getUniformLocation(program, 'uZXPalette[0]'),
+    petsciiPalette: gl.getUniformLocation(program, 'uPetsciiPalette[0]')
   };
 
   const identityMatrix = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
@@ -1689,8 +1689,12 @@
   gl.uniformMatrix4fv(uniforms.model, false, identityMatrix);
   gl.uniform3fv(uniforms.lightDir, new Float32Array([-0.35, 0.9, 0.32]));
   gl.uniform1f(uniforms.gridSize, geometry.segments);
-  gl.uniform3fv(uniforms.zxPalette, flattenedZX);
-  gl.uniform3fv(uniforms.petsciiPalette, flattenedPET);
+  if (uniforms.zxPalette) {
+    gl.uniform3fv(uniforms.zxPalette, flattenedZX);
+  }
+  if (uniforms.petsciiPalette) {
+    gl.uniform3fv(uniforms.petsciiPalette, flattenedPET);
+  }
 
   gl.enable(gl.DEPTH_TEST);
   gl.enable(gl.CULL_FACE);


### PR DESCRIPTION
## Summary
- request the correct uniform locations for the ZX and PETSCII palette arrays
- guard uniform uploads so the terrain renderer no longer throws when the arrays are absent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de97d856f8832ab105f866fe39bf99