### PR TITLE
Update Orbit OS terminal and version to 0.1.3

### DIFF
--- a/apps/app1/app-data/app1.json
+++ b/apps/app1/app-data/app1.json
@@ -16,7 +16,7 @@
           "type": "file-manager"
         },
         {
-          "label": "Exit Orbit OS v 0.1.2"
+          "label": "Exit Orbit OS v 0.1.3"
         }
       ]
     },
@@ -94,11 +94,38 @@
       ]
     }
   ],
-  "status": "Orbit OS v 0.1.2 ready.",
+  "status": "Orbit OS v 0.1.3 ready.",
+  "terminal": {
+    "banner": [
+      "Orbit OS v{version} CLI",
+      "(c) 2025 CyborgsDream",
+      "System date: {date}",
+      "System time: {time}",
+      ""
+    ],
+    "hint": "Type <strong>help</strong> or try <code>status</code>.",
+    "responses": {
+      "status": [
+        "Core services: ONLINE",
+        "Creative drives mounted successfully.",
+        "Build version: v{version}"
+      ],
+      "whoami": "orbit-user",
+      "ls apps": [
+        "cloud-storage.html",
+        "documonster.html",
+        "scanx.html"
+      ]
+    },
+    "fallback": {
+      "type": "info",
+      "message": "Command \"{command}\" executed."
+    }
+  },
   "welcome": {
-    "title": "Orbit OS v 0.1.2",
+    "title": "Orbit OS v 0.1.3",
     "lines": [
-      "Welcome to Orbit OS v 0.1.2.",
+      "Welcome to Orbit OS v 0.1.3.",
       "Built in-house for independent creators.",
       "(c) 2025 CyborgsDream"
     ],
@@ -154,19 +181,19 @@
   "windows": {
     "system-info": {
       "title": "System Information",
-      "content": "<h2>Orbit OS v 0.1.2 Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>Orbit OS v 0.1.2</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Creative Control</div></div>",
+      "content": "<h2>Orbit OS v 0.1.3 Demo Machine</h2><p>Motorola 68030 @ 25MHz</p><p>2MB Chip RAM + 8MB Fast RAM</p><p>Kickstart 2.04</p><p>Orbit OS v 0.1.3</p><p>Display: 640x512 (ECS)</p><p>Floppy: 880KB 3.5\"</p><p>HD: 120MB SCSI</p><div style=\"margin-top: 20px; text-align: center;\"><div style=\"display: inline-block; padding: 10px; background: #0000aa; color: white;\">Creative Control</div></div>",
       "width": 320,
       "height": 300
     },
     "terminal": {
       "title": "CLI",
-      "content": "<div class=\"terminal\" role=\"application\"><div class=\"terminal-screen\" tabindex=\"0\" aria-label=\"Orbit OS command line\"><div class=\"terminal-output\"></div><div class=\"terminal-input-line\"><span class=\"terminal-prompt\">orbit&gt;</span><span class=\"terminal-input\" aria-live=\"polite\"></span><span class=\"terminal-cursor\">█</span></div></div><div class=\"terminal-hints\">Type <strong>help</strong> to list available commands.</div></div>",
+      "content": "<div class=\"terminal\" role=\"application\"><div class=\"terminal-screen\" tabindex=\"0\" aria-label=\"Orbit OS command line\"><div class=\"terminal-output\"></div><div class=\"terminal-input-line\"><span class=\"terminal-prompt\">orbit&gt;</span><span class=\"terminal-input\" aria-live=\"polite\"></span><span class=\"terminal-cursor\">█</span></div></div><div class=\"terminal-hints\">Type <strong>help</strong> or try <code>status</code>.</div></div>",
       "width": 520,
       "height": 320
     },
     "text-editor": {
       "title": "Text Editor",
-      "content": "<div class=\"text-editor text-editor--wrap text-editor--mono\"><div class=\"text-editor-toolbar\"><div class=\"text-editor-menu\"><button type=\"button\" data-action=\"options\" class=\"text-editor-btn\" aria-expanded=\"false\">Options</button><button type=\"button\" data-action=\"new\" class=\"text-editor-btn\">New</button><button type=\"button\" data-action=\"save\" class=\"text-editor-btn\">Save</button><button type=\"button\" data-action=\"load\" class=\"text-editor-btn\">Load</button><button type=\"button\" data-action=\"word-count\" class=\"text-editor-btn\">Word Count</button><input type=\"file\" id=\"text-editor-file\" accept=\".txt,.md,.json,text/plain\" hidden></div><div class=\"text-editor-spacer\"></div><button type=\"button\" id=\"text-editor-export\" class=\"text-editor-btn primary\">Export PDF</button></div><div class=\"text-editor-options\" id=\"text-editor-options\" aria-hidden=\"true\"><label class=\"text-editor-option\"><span>Soft wrap text</span><input type=\"checkbox\" id=\"text-editor-option-wrap\" checked></label><label class=\"text-editor-option\"><span>Monospace mode</span><input type=\"checkbox\" id=\"text-editor-option-mono\" checked></label><label class=\"text-editor-option\"><span>Auto-save drafts</span><input type=\"checkbox\" id=\"text-editor-option-autosave\" checked></label><label class=\"text-editor-option text-editor-option--filename\"><span>Default filename</span><input type=\"text\" id=\"text-editor-option-filename\" value=\"orbit-notes.txt\" spellcheck=\"false\"></label><div class=\"text-editor-option text-editor-option--actions\"><span>Need your last copy?</span><button type=\"button\" id=\"text-editor-restore\" class=\"text-editor-btn subtle\">Restore Last Draft</button></div></div><div class=\"text-editor-status-row\"><div id=\"text-editor-status\">Ready.</div><div id=\"text-editor-stats\"></div></div><textarea id=\"text-editor-area\" class=\"text-editor-area\" autocomplete=\"off\">Welcome to Orbit OS v 0.1.2!\n\n• Crafted for focused creative work.\n• Windows snap, remember their state, and respect your layout.\n• Use the menu above to manage drafts.\n\nStay tuned for additional native tools in upcoming builds.</textarea></div>",
+      "content": "<div class=\"text-editor text-editor--wrap text-editor--mono\"><div class=\"text-editor-toolbar\"><div class=\"text-editor-menu\"><button type=\"button\" data-action=\"options\" class=\"text-editor-btn\" aria-expanded=\"false\">Options</button><button type=\"button\" data-action=\"new\" class=\"text-editor-btn\">New</button><button type=\"button\" data-action=\"save\" class=\"text-editor-btn\">Save</button><button type=\"button\" data-action=\"load\" class=\"text-editor-btn\">Load</button><button type=\"button\" data-action=\"word-count\" class=\"text-editor-btn\">Word Count</button><input type=\"file\" id=\"text-editor-file\" accept=\".txt,.md,.json,text/plain\" hidden></div><div class=\"text-editor-spacer\"></div><button type=\"button\" id=\"text-editor-export\" class=\"text-editor-btn primary\">Export PDF</button></div><div class=\"text-editor-options\" id=\"text-editor-options\" aria-hidden=\"true\"><label class=\"text-editor-option\"><span>Soft wrap text</span><input type=\"checkbox\" id=\"text-editor-option-wrap\" checked></label><label class=\"text-editor-option\"><span>Monospace mode</span><input type=\"checkbox\" id=\"text-editor-option-mono\" checked></label><label class=\"text-editor-option\"><span>Auto-save drafts</span><input type=\"checkbox\" id=\"text-editor-option-autosave\" checked></label><label class=\"text-editor-option text-editor-option--filename\"><span>Default filename</span><input type=\"text\" id=\"text-editor-option-filename\" value=\"orbit-notes.txt\" spellcheck=\"false\"></label><div class=\"text-editor-option text-editor-option--actions\"><span>Need your last copy?</span><button type=\"button\" id=\"text-editor-restore\" class=\"text-editor-btn subtle\">Restore Last Draft</button></div></div><div class=\"text-editor-status-row\"><div id=\"text-editor-status\">Ready.</div><div id=\"text-editor-stats\"></div></div><textarea id=\"text-editor-area\" class=\"text-editor-area\" autocomplete=\"off\">Welcome to Orbit OS v 0.1.3!\n\n• Crafted for focused creative work.\n• Windows snap, remember their state, and respect your layout.\n• Use the menu above to manage drafts.\n\nStay tuned for additional native tools in upcoming builds.</textarea></div>",
       "width": 560,
       "height": 420
     },

--- a/apps/app1/app-index.html
+++ b/apps/app1/app-index.html
@@ -12,7 +12,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Orbit OS v 0.1.2</title>
+    <title>Orbit OS v 0.1.3</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=VT323&display=swap">
     <style>
         * {
@@ -250,7 +250,7 @@
         }
         
         .window-content {
-            padding: 15px;
+            padding: 10px;
             flex: 1;
             overflow: auto;
             color: #000;
@@ -417,7 +417,7 @@
         .terminal-screen {
             flex: 1;
             overflow: auto;
-            padding: 12px;
+            padding: 10px;
             outline: none;
         }
 
@@ -1084,6 +1084,9 @@
         const scanxFrames = new Set();
 
         const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+        const ORBIT_VERSION = '0.1.3';
+        window.ORBIT_VERSION = ORBIT_VERSION;
+        window.ORBIT_TERMINAL_CONFIG = {};
 
         function setBootProgress(value, status) {
             if (!bootLoader) return;
@@ -1842,6 +1845,7 @@
             const res = await fetch('app-data/app1.json');
             setBootProgress(0.38, 'Loading system manifest…');
             appData = await res.json();
+            window.ORBIT_TERMINAL_CONFIG = appData.terminal || {};
             console.info('System manifest loaded.');
             setBootProgress(0.5, 'Mounting creative drives…');
 

--- a/apps/app1/app-js/terminal.js
+++ b/apps/app1/app-js/terminal.js
@@ -6,6 +6,136 @@ const outputEl = win?.querySelector('.terminal-output');
 const inputEl = win?.querySelector('.terminal-input');
 const hintsEl = win?.querySelector('.terminal-hints');
 
+const ORBIT_VERSION = typeof window !== 'undefined' && window.ORBIT_VERSION
+    ? window.ORBIT_VERSION
+    : '0.1.3';
+
+const terminalConfig = typeof window !== 'undefined' && window.ORBIT_TERMINAL_CONFIG
+    ? window.ORBIT_TERMINAL_CONFIG
+    : {};
+
+const commandResponses = new Map();
+const exactResponses = new Map();
+const customPatterns = new Map();
+let wildcardResponse = null;
+
+function registerResponse(pattern, value, targetMap) {
+    const trimmed = (pattern || '').trim();
+    if (!trimmed) return;
+    const key = trimmed.toLowerCase();
+    customPatterns.set(key, trimmed);
+    targetMap.set(key, { pattern: trimmed, response: value });
+}
+
+if (terminalConfig && typeof terminalConfig === 'object' && terminalConfig.responses) {
+    const entries = Object.entries(terminalConfig.responses);
+    entries.forEach(([pattern, value]) => {
+        if (pattern === '*') {
+            wildcardResponse = value;
+            return;
+        }
+        if (pattern.includes(' ')) {
+            registerResponse(pattern, value, exactResponses);
+        } else {
+            registerResponse(pattern, value, commandResponses);
+        }
+    });
+}
+
+const defaultFallback = 'Executed "{command}".';
+
+function applyTemplate(str, context) {
+    return str.replace(/\{(command|cmd|args|version|date|time|arg(\d+))\}/gi, (match, token, index) => {
+        if (!token) return match;
+        const lower = token.toLowerCase();
+        if (lower === 'command') return context.command;
+        if (lower === 'cmd') return context.cmd;
+        if (lower === 'args') return context.args;
+        if (lower === 'version') return context.version;
+        if (lower === 'date') return context.date;
+        if (lower === 'time') return context.time;
+        if (lower.startsWith('arg')) {
+            const argIndex = Number(index);
+            if (Number.isFinite(argIndex)) {
+                return context.argsArray[argIndex] ?? '';
+            }
+        }
+        return match;
+    });
+}
+
+function renderResponse(value, context, prefix = '') {
+    const lines = [];
+    const enqueue = (line, injectedPrefix = prefix) => {
+        if (typeof line !== 'string') {
+            line = line != null ? String(line) : '';
+        }
+        const formatted = applyTemplate(line, context);
+        formatted.split(/\r?\n/).forEach(part => {
+            lines.push(injectedPrefix ? `${injectedPrefix}${part}` : part);
+        });
+    };
+
+    const process = (input, injectedPrefix = prefix) => {
+        if (input == null) {
+            return;
+        }
+        if (Array.isArray(input)) {
+            input.forEach(item => process(item, injectedPrefix));
+            return;
+        }
+        if (typeof input === 'object') {
+            const typePrefix = input.type ? `[${String(input.type).toUpperCase()}] ` : injectedPrefix;
+            let consumed = false;
+            if (Array.isArray(input.lines)) {
+                input.lines.forEach(item => process(item, typePrefix));
+                consumed = true;
+            }
+            if (typeof input.message === 'string') {
+                enqueue(input.message, typePrefix);
+                consumed = true;
+            }
+            if (!consumed) {
+                enqueue(JSON.stringify(input), injectedPrefix);
+            }
+            return;
+        }
+        enqueue(input, injectedPrefix);
+    };
+
+    process(value, prefix);
+    return lines;
+}
+
+function createContext(rawInput, command, args) {
+    const now = new Date();
+    return {
+        command: rawInput,
+        cmd: command,
+        args: args.join(' '),
+        argsArray: args,
+        version: ORBIT_VERSION,
+        date: now.toLocaleDateString(),
+        time: now.toLocaleTimeString()
+    };
+}
+
+function resolveCustomResponse(input, command, args) {
+    const context = createContext(input, command, args);
+    const exact = exactResponses.get(input.toLowerCase());
+    if (exact) {
+        return { context, lines: renderResponse(exact.response, context) };
+    }
+    const cmdEntry = commandResponses.get(command.toLowerCase());
+    if (cmdEntry) {
+        return { context, lines: renderResponse(cmdEntry.response, context) };
+    }
+    if (wildcardResponse != null) {
+        return { context, lines: renderResponse(wildcardResponse, context) };
+    }
+    return { context, lines: null };
+}
+
 if (screen) {
     screen.focus();
     screen.addEventListener('click', () => screen.focus());
@@ -40,7 +170,7 @@ function showHints(message) {
 
 const commands = {
     help() {
-        appendOutput([
+        const lines = [
             'Available commands:',
             '  help       Show this help message',
             '  clear      Clear the screen',
@@ -48,7 +178,21 @@ const commands = {
             '  time       Show the current time',
             '  version    Display Orbit OS version',
             '  echo TEXT  Repeat the provided text'
-        ]);
+        ];
+        const custom = Array.from(customPatterns.values())
+            .filter(pattern => pattern && pattern !== '*')
+            .sort((a, b) => a.localeCompare(b));
+        if (custom.length) {
+            lines.push('', 'Custom responses:');
+            custom.forEach(pattern => {
+                const display = pattern.includes(' ') ? `  "${pattern}"` : `  ${pattern}`;
+                lines.push(display);
+            });
+        }
+        if (wildcardResponse != null) {
+            lines.push('', 'Wildcard handler active for unmatched commands.');
+        }
+        appendOutput(lines);
     },
     clear() {
         if (outputEl) outputEl.innerHTML = '';
@@ -63,7 +207,7 @@ const commands = {
         appendOutput(new Date().toLocaleTimeString());
     },
     version() {
-        appendOutput('Orbit OS v0.1.2');
+        appendOutput(`Orbit OS v${ORBIT_VERSION}`);
     },
     echo(...args) {
         appendOutput(args.join(' '));
@@ -79,8 +223,19 @@ function executeCommand(raw) {
     const fn = commands[cmd.toLowerCase()];
     if (fn) {
         fn(...args);
-    } else {
-        appendOutput(`Unknown command: ${cmd}. Type "help".`);
+        return;
+    }
+
+    const { context, lines } = resolveCustomResponse(input, cmd, args);
+    if (Array.isArray(lines) && lines.length) {
+        appendOutput(lines);
+        return;
+    }
+
+    const fallbackSource = terminalConfig.fallback ?? defaultFallback;
+    const fallbackLines = renderResponse(fallbackSource, context);
+    if (fallbackLines.length) {
+        appendOutput(fallbackLines);
     }
 }
 
@@ -135,12 +290,21 @@ if (screen) {
     });
 }
 
-appendOutput([
-    'Orbit OS v0.1.2 CLI',
+const introContext = createContext('', '', []);
+const bannerSource = terminalConfig.banner ?? [
+    'Orbit OS v{version} CLI',
     '(c) 2025 CyborgsDream',
-    `System date: ${new Date().toLocaleDateString()}`,
-    `System time: ${new Date().toLocaleTimeString()}`,
+    'System date: {date}',
+    'System time: {time}',
     ''
-]);
-showHints('Type <strong>help</strong> to list available commands.');
+];
+const bannerLines = renderResponse(bannerSource, introContext);
+if (bannerLines.length) {
+    appendOutput(bannerLines);
+}
+
+const hintMessage = typeof terminalConfig.hint === 'string'
+    ? terminalConfig.hint
+    : 'Type <strong>help</strong> to list available commands.';
+showHints(hintMessage);
 updateInput();

--- a/apps/app1/documonster.html
+++ b/apps/app1/documonster.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta http-equiv="Content-Language" content="en" />
-<title>Docu Monster Studio Pro — Orbit OS v 0.1.2</title>
+<title>Docu Monster Studio Pro — Orbit OS v 0.1.3</title>
 <style>
   /* ===== Base ===== */
   *,*::before,*::after{ box-sizing:border-box; }
@@ -493,7 +493,7 @@
     </div>
     <div class="win-group">
       <span class="win-stat" id="status">Ready.</span>
-      <span class="win-stat" id="ver">Orbit OS v 0.1.2 • Docu Monster Studio Pro 0.1.1</span>
+      <span class="win-stat" id="ver">Orbit OS v 0.1.3 • Docu Monster Studio Pro 0.1.1</span>
     </div>
   </div>
 

--- a/data/index.json
+++ b/data/index.json
@@ -1,7 +1,7 @@
 {
   "apps": [
     {
-      "name": "Orbit OS v 0.1.2",
+      "name": "Orbit OS v 0.1.3",
       "file": "apps/app1/app-index.html",
       "short": "lorem ipsum doloret sit amet",
       "long": "This is the first demo showcasing features."

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--
-Version: 0.1.2
+Version: 0.1.3
 Codename: Celestia
 Change Log:
  - Initial responsive boilerplate
@@ -13,7 +13,7 @@ Change Log:
  - Switched object labels to <h3> elements
  - Made info text white for visibility
  - Removed console log background and limited visibility to 3 seconds
- - Bumped version to 0.1.2
+ - Bumped version to 0.1.3
  - Enabled dynamic 16:9 scaling for larger screens
  - Reduced DEMOS text wave range and limited movement to Z axis
  - Raised demo objects and enabled inter-object shadows
@@ -94,7 +94,7 @@ Change Log:
     <div id="scene-container">
       <h1 id="cinematic-heading">demos</h1>
       <div id="fps-counter">0 FPS</div>
-      <div id="version-number">v0.1.2</div>
+      <div id="version-number">v0.1.3</div>
       <div id="console-log"></div>
       <div id="app-info">
         <span id="close-info" class="close-icon" aria-label="Close">&times;</span>

--- a/mini_os.html
+++ b/mini_os.html
@@ -12,7 +12,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Orbit OS v 0.1.2</title>
+    <title>Orbit OS v 0.1.3</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=VT323&display=swap">
     <script>
         window.ORBIT_BASE_PATH = 'apps/app1/';
@@ -253,7 +253,7 @@
         }
         
         .window-content {
-            padding: 15px;
+            padding: 10px;
             flex: 1;
             overflow: auto;
             color: #000;
@@ -406,7 +406,7 @@
         .terminal-screen {
             flex: 1;
             overflow: auto;
-            padding: 12px;
+            padding: 10px;
             outline: none;
         }
 
@@ -988,6 +988,9 @@
         let windowStates = JSON.parse(localStorage.getItem('windowStates') || '{}');
 
         const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+        const ORBIT_VERSION = '0.1.3';
+        window.ORBIT_VERSION = ORBIT_VERSION;
+        window.ORBIT_TERMINAL_CONFIG = {};
 
         function setBootProgress(value, status) {
             if (!bootLoader) return;
@@ -1540,6 +1543,7 @@
             const res = await fetch(`${ORBIT_BASE_PATH}app-data/app1.json`);
             setBootProgress(0.38, 'Loading system manifest…');
             appData = await res.json();
+            window.ORBIT_TERMINAL_CONFIG = appData.terminal || {};
             setBootProgress(0.5, 'Mounting creative drives…');
 
             persistWindows = appData.settings && appData.settings.persistWindows !== false;


### PR DESCRIPTION
## Summary
- add data-driven terminal responses with templated fallback handling so arbitrary commands can display results
- tighten window padding, share version metadata via globals, and bump Orbit OS references to 0.1.3 across entry points
- publish terminal response presets and updated messaging in the app manifest for the new CLI behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd60813404832a80119f40cdaecaba