### PR TITLE
Fix terrain camera view matrix orientation

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -1724,32 +1724,38 @@
       }
 
       function mat4LookAt(out, eye, center, up) {
-        const fx = center[0] - eye[0];
-        const fy = center[1] - eye[1];
-        const fz = center[2] - eye[2];
-        const fl = Math.hypot(fx, fy, fz) || 1;
-        const f0 = fx / fl;
-        const f1 = fy / fl;
-        const f2 = fz / fl;
+        let zx = eye[0] - center[0];
+        let zy = eye[1] - center[1];
+        let zz = eye[2] - center[2];
+        let len = Math.hypot(zx, zy, zz);
+        if (len === 0) {
+          zz = 1;
+        } else {
+          zx /= len;
+          zy /= len;
+          zz /= len;
+        }
 
-        const sx = f1 * up[2] - f2 * up[1];
-        const sy = f2 * up[0] - f0 * up[2];
-        const sz = f0 * up[1] - f1 * up[0];
-        const sl = Math.hypot(sx, sy, sz) || 1;
-        const s0 = sx / sl;
-        const s1 = sy / sl;
-        const s2 = sz / sl;
+        let xx = up[1] * zz - up[2] * zy;
+        let xy = up[2] * zx - up[0] * zz;
+        let xz = up[0] * zy - up[1] * zx;
+        len = Math.hypot(xx, xy, xz);
+        if (len !== 0) {
+          xx /= len;
+          xy /= len;
+          xz /= len;
+        }
 
-        const ux = s1 * f2 - s2 * f1;
-        const uy = s2 * f0 - s0 * f2;
-        const uz = s0 * f1 - s1 * f0;
+        const yx = zy * xz - zz * xy;
+        const yy = zz * xx - zx * xz;
+        const yz = zx * xy - zy * xx;
 
-        out[0] = s0; out[1] = ux; out[2] = -f0; out[3] = 0;
-        out[4] = s1; out[5] = uy; out[6] = -f1; out[7] = 0;
-        out[8] = s2; out[9] = uz; out[10] = -f2; out[11] = 0;
-        out[12] = -(s0 * eye[0] + s1 * eye[1] + s2 * eye[2]);
-        out[13] = -(ux * eye[0] + uy * eye[1] + uz * eye[2]);
-        out[14] = f0 * eye[0] + f1 * eye[1] + f2 * eye[2];
+        out[0] = xx; out[1] = yx; out[2] = zx; out[3] = 0;
+        out[4] = xy; out[5] = yy; out[6] = zy; out[7] = 0;
+        out[8] = xz; out[9] = yz; out[10] = zz; out[11] = 0;
+        out[12] = -(xx * eye[0] + xy * eye[1] + xz * eye[2]);
+        out[13] = -(yx * eye[0] + yy * eye[1] + yz * eye[2]);
+        out[14] = -(zx * eye[0] + zy * eye[1] + zz * eye[2]);
         out[15] = 1;
         return out;
       }


### PR DESCRIPTION
## Summary
- replace the custom lookAt implementation with a standard formulation
- ensure the camera basis vectors preserve correct handedness to fix face culling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e162096694832a8879e5770d287ca0