### PR TITLE
Fix terrain mesh winding order

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -1468,11 +1468,11 @@
             const c = (z + 1) * (segments + 1) + x;
             const d = c + 1;
             indices[writeIndex++] = a;
-            indices[writeIndex++] = c;
-            indices[writeIndex++] = b;
             indices[writeIndex++] = b;
             indices[writeIndex++] = c;
+            indices[writeIndex++] = b;
             indices[writeIndex++] = d;
+            indices[writeIndex++] = c;
           }
         }
 


### PR DESCRIPTION
## Summary
- correct the triangle winding order used when building the terrain index buffer to keep faces front-facing

## Testing
- manually loaded http://127.0.0.1:8000/apps/terrain/index.html

------
https://chatgpt.com/codex/tasks/task_e_68e162d724dc832a9caf4735f4b690b3