### PR TITLE
Fix terrain pointer yaw direction

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -1937,7 +1937,7 @@
         const sensitivity = pointerState.pointerType === 'touch'
           ? controls.touchDragSensitivity
           : controls.dragSensitivity;
-        camera.yaw -= dx * sensitivity;
+        camera.yaw += dx * sensitivity;
         camera.pitch = Math.max(camera.minPitch, Math.min(camera.maxPitch, camera.pitch - dy * sensitivity));
       });
 


### PR DESCRIPTION
## Summary
- correct the horizontal drag handling in the terrain pointer look control so right drags turn right

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e169134a64832aa6a5b7eeb6cb0a64