### PR TITLE
Fix terrain forward movement direction

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -1817,7 +1817,7 @@
       }
 
       function updateCamera(dt) {
-        const forward = [Math.sin(camera.yaw), 0, Math.cos(camera.yaw)];
+        const forward = [-Math.sin(camera.yaw), 0, -Math.cos(camera.yaw)];
         const right = [Math.cos(camera.yaw), 0, -Math.sin(camera.yaw)];
         let moveX = 0;
         let moveZ = 0;


### PR DESCRIPTION
## Summary
- align the terrain camera's forward vector with its view direction so keyboard movement matches the visual orientation

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e175faf098832aac94baabbf6b2703