### PR TITLE
Treat root path as canonical for index.html redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,9 @@
         : null;
       var target = canonicalLink || document.documentElement.getAttribute('data-target') || 'index.html';
       var targetPath = new URL(target, window.location.href).pathname;
-      var isCanonical = window.location.pathname === targetPath || window.location.pathname.endsWith(targetPath);
+      var currentPath = window.location.pathname || '/';
+      var isRootAlias = currentPath === '/' && targetPath.endsWith('/index.html');
+      var isCanonical = currentPath === targetPath || currentPath.endsWith(targetPath) || isRootAlias;
 
       var fallback = document.getElementById('redirect-fallback');
       var appShell = document.getElementById('app-shell');


### PR DESCRIPTION
### Motivation
- The client-side redirect logic treated only exact or suffix path matches as canonical, which caused the root path (`/`) to redirect away from `index.html` and prevented the 3D scene/app shell from being shown.

### Description
- In `index.html` add `currentPath` and `isRootAlias` and update the `isCanonical` check to include the root-as-index alias so `isCanonical` is true when visiting `/` for an `index.html` target.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e104d618832aad0a5cf2ee689b6b)