### PR TITLE
Add redirect service worker and fix registration path

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
 
         var timer = setTimeout(function () { if (!didRespond) finishRedirect(); }, SW_WAIT_MS);
 
-        navigator.serviceWorker.register('/sw-redirect.js').then(function () {
+        navigator.serviceWorker.register('sw-redirect.js').then(function () {
           return navigator.serviceWorker.ready;
         }).then(function () {
           didRespond = true;

--- a/sw-redirect.js
+++ b/sw-redirect.js
@@ -1,0 +1,14 @@
+self.addEventListener('install', event => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.mode !== 'navigate') {
+    return;
+  }
+  event.respondWith(fetch(event.request));
+});


### PR DESCRIPTION
### Motivation
- The client redirect flow attempted to register a service worker using an absolute path which can fail when the site is served from a subpath, causing a missing-file error. 
- A missing `sw-redirect.js` caused the registration promise to fail and produced `Failed to load resource: 404` console errors during page load. 

### Description
- Update `index.html` to register the service worker with a relative path by changing `navigator.serviceWorker.register('/sw-redirect.js')` to `navigator.serviceWorker.register('sw-redirect.js')`.
- Add a minimal `sw-redirect.js` implementing `install`, `activate`, and a `fetch` handler that forwards navigation requests with `fetch(event.request)` so registration succeeds.
- Files changed: `index.html` (registration path) and new `sw-redirect.js` (service worker implementation).

### Testing
- Started the local server with `node server.js` and confirmed the server was running (succeeded).
- Verified the new `sw-redirect.js` is being served using `curl -I http://localhost:8000/sw-redirect.js` and received `HTTP/1.1 200 OK` (succeeded).
- Ran a Playwright script to load `index.html` which still produced a `Failed to load resource: 404 (Not Found)` console error indicating an unrelated missing asset remains to be addressed (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69627dae0c84832aa2203505967202c2)