### PR TITLE
Fix CORS for terrain WebGPU imports by switching CDN

### DIFF
--- a/apps/terrain/index.html
+++ b/apps/terrain/index.html
@@ -1190,8 +1190,8 @@
     </div>
   </div>
   <script type="module">
-  import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
-  import { WebGPURenderer } from 'https://unpkg.com/three@0.160.0/examples/jsm/renderers/WebGPURenderer.js';
+  import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
+  import { WebGPURenderer } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/renderers/WebGPURenderer.js';
   import { initConsoleLogs } from '../../shared/consolelogs.js';
 
   const consoleLogEl = document.getElementById('console-log');


### PR DESCRIPTION
### Motivation
- The `WebGPURenderer.js` import loaded from `unpkg.com` was being blocked by CORS when the site was served from the deployed origin, so switching to a CDN that serves permissive CORS headers is needed.

### Description
- Updated `apps/terrain/index.html` to replace `https://unpkg.com/three@0.160.0/...` imports with `https://cdn.jsdelivr.net/npm/three@0.160.0/...` for both `three.module.js` and `examples/jsm/renderers/WebGPURenderer.js`.

### Testing
- Verified the updated import lines with `rg` and inspected the file lines with `nl` to confirm the imports now point to `https://cdn.jsdelivr.net/npm/three@0.160.0/...` and the change is present in `apps/terrain/index.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b95450540832a9387ca94cabaaf4e)